### PR TITLE
Make more library friendly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ In case you feel like you've made a valuable contribution, but you don't know ho
 To create a release you need write permission on the repository.
 
 1. Check the author list in [`CITATION.cff`](CITATION.cff)
-1. Bump the version in [pyproject.toml](pyproject.toml).
+1. Bump the version in [src/powerfit_em/__init__.py](src/powerfit_em/__init__.py)
 1. Go to the [GitHub release page](https://github.com/haddocking/powerfit/releases)
 1. Press draft a new release button
 1. Fill tag, title and description field. For tag use version from pyproject.toml and prepend with "v" character. For description use "Rigid body fitting of high-resolution structures in low-resolution cryo-electron microscopy density maps." line plus press "Generate release notes" button.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ dependencies = [
     "numpy>=1.8",
     # pyfftw binary wheel is not available on wasm or on macOS <14 arm, so fallback to numpy for wasm and macOS
     "pyfftw>=0.12.0; platform_machine != 'wasm32' and sys_platform != 'darwin'",
-    "scipy"
+    "scipy",
+    "tqdm",
+    "rich",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powerfit-em"
-version = "3.0.2"
 description = "Rigid body fitting of high-resolution structures in low-resolution cryo-electron microscopy density maps"
 authors = [{ name = "Gydo C.P. van Zundert", email = "g.c.p.vanzundert@uu.nl" }]
 maintainers = [{ name = "BonvinLab" }, { email = "bonvinlab.support@uu.nl" }]
 requires-python = ">=3.10"
-dynamic = ["readme"]
+dynamic = ["readme", "version"]
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -60,6 +59,7 @@ powerfit_em = ["data/*.npy", "kernels.cl", "_powerfit.pyx"]
 
 [tool.setuptools.dynamic]
 readme = {file = "README.md", content-type = "text/markdown"}
+version = {attr = "powerfit_em.__version__"}
 
 [tool.cibuildwheel]
 # Skip Pypy and older Alpine versions

--- a/src/powerfit_em/__init__.py
+++ b/src/powerfit_em/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 
 from .volume import Volume, structure_to_shape_like
 from .structure import Structure

--- a/src/powerfit_em/__init__.py
+++ b/src/powerfit_em/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "3.0.2"
+
 from .volume import Volume, structure_to_shape_like
 from .structure import Structure
 from .rotations import proportional_orientations, quat_to_rotmat

--- a/src/powerfit_em/analyzer.py
+++ b/src/powerfit_em/analyzer.py
@@ -100,7 +100,7 @@ class Analyzer(object):
         Arguments:
             out: str, output file name (default: 'solutions.out')
             delimiter: str, delimiter for the output file. Defaults to fixed width output.
-                Can be ',' or '\t'.
+                Can be ',' or '\t'. With delimiter set the header will not have leading '#'.
         """
 
         if self._solutions is None:
@@ -116,6 +116,7 @@ class Analyzer(object):
                     f.write(line.format(n + 1, *sol))
             else:
                 # Write header
+                headers[0] = headers[0].lstrip('#')
                 f.write(delimiter.join(headers) + '\n')
                 for n, sol in enumerate(self._solutions):
                     row = [n + 1] + sol

--- a/src/powerfit_em/analyzer.py
+++ b/src/powerfit_em/analyzer.py
@@ -1,6 +1,3 @@
-
-
-
 from numpy import zeros, bool, greater_equal, log
 from scipy.ndimage import label, maximum_position
 
@@ -97,17 +94,33 @@ class Analyzer(object):
             positions += maximum_position(self._corr, labels, list(range(1, nfeatures + 1)))
         self._positions = set(positions)
 
-    def tofile(self, out='solutions.out'):
+    def tofile(self, out='solutions.out', delimiter=None):
+        """Write solutions to file.
+
+        Arguments:
+            out: str, output file name (default: 'solutions.out')
+            delimiter: str, delimiter for the output file. Defaults to fixed width output.
+                Can be ',' or '\t'.
+        """
 
         if self._solutions is None:
             self._generate_solutions()
 
+        headers = '#rank cc Fish-z rel-z x y z a11 a12 a13 a21 a22 a23 a31 a32 a33'.split()
         with open(out, 'w') as f:
-            headers = '#rank cc Fish-z rel-z x y z a11 a12 a13 a21 a22 a23 a31 a32 a33'.split()
-            line = ' '.join(['{:<6s}'] + ['{:>6s}'] * 3 + ['{:>8s}'] * 3 + ['{:>6s}'] * 9) + '\n'
-            f.write(line.format(*headers))
-            line = ' '.join(['{:<6d}'] + ['{:6.3f}'] * 3 + ['{:8.3f}'] * 3 + ['{:6.3f}'] * 9) + '\n'
-            for n, sol in enumerate(self._solutions):
-                f.write(line.format(n + 1, *sol))
-            
+            if delimiter is None:
+                line = ' '.join(['{:<6s}'] + ['{:>6s}'] * 3 + ['{:>8s}'] * 3 + ['{:>6s}'] * 9) + '\n'
+                f.write(line.format(*headers))
+                line = ' '.join(['{:<6d}'] + ['{:6.3f}'] * 3 + ['{:8.3f}'] * 3 + ['{:6.3f}'] * 9) + '\n'
+                for n, sol in enumerate(self._solutions):
+                    f.write(line.format(n + 1, *sol))
+            else:
+                # Write header
+                f.write(delimiter.join(headers) + '\n')
+                for n, sol in enumerate(self._solutions):
+                    row = [n + 1] + sol
+                    # Format all values as floats with 3 decimals except rank (int)
+                    row_str = [str(row[0])] + [f"{v:.3f}" for v in row[1:4]] + [f"{v:.3f}" for v in row[4:7]] + [f"{v:.3f}" for v in row[7:]]
+                    f.write(delimiter.join(row_str) + '\n')
+
 

--- a/src/powerfit_em/powerfit.py
+++ b/src/powerfit_em/powerfit.py
@@ -260,6 +260,7 @@ def powerfit(target_volume: BinaryIO,
     queues = None
     if gpu:
         import pyopencl as cl
+        # TODO allow to omit platform, so gpu='4' runs 5th device on first platform
         if isinstance(gpu, str) and ':' in gpu:
             platform_idx, device_idx = map(int, gpu.split(':'))
         else:

--- a/src/powerfit_em/powerfit.py
+++ b/src/powerfit_em/powerfit.py
@@ -173,7 +173,6 @@ def make_parser():
         help="Set the logging level.",
     )
     p.add_argument(
-        "-del",
         "--delimiter",
         dest="delimiter",
         type=str,

--- a/src/powerfit_em/powerfit.py
+++ b/src/powerfit_em/powerfit.py
@@ -172,6 +172,15 @@ def make_parser():
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Set the logging level.",
     )
+    p.add_argument(
+        "-del",
+        "--delimiter",
+        dest="delimiter",
+        type=str,
+        default=None,
+        metavar="<str>",
+        help="Delimiter used in the 'solutions.out' file. For example use ',' or '\\t'. Defaults to fixed width.",
+    )
 
     return p
 
@@ -235,6 +244,7 @@ def main():
         num=args.num,
         gpu=args.gpu,
         nproc=args.nproc,
+        delimiter=args.delimiter,
     )
 
 
@@ -252,7 +262,9 @@ def powerfit(target_volume: BinaryIO,
              directory: str='.',
              num: int=10,
              gpu: str | None =None, 
-             nproc: int=1):
+             nproc: int=1,
+             delimiter: str = None,
+             ):
     time0 = time()
     mkdir_p(directory)
 
@@ -372,7 +384,7 @@ def powerfit(target_volume: BinaryIO,
     Volume(pf._lcc, target.voxelspacing, target.origin).tofile(
         join(directory, "lcc.mrc")
     )
-    analyzer.tofile(join(directory, "solutions.out"))
+    analyzer.tofile(join(directory, "solutions.out"), delimiter=delimiter)
 
     logger.info("Writing PDBs to file.")
     n = min(num, len(analyzer.solutions))

--- a/src/powerfit_em/powerfit.py
+++ b/src/powerfit_em/powerfit.py
@@ -15,6 +15,7 @@ from tqdm.rich import tqdm as rich_tqdm
 from tqdm.auto import tqdm
 
 from powerfit_em import (
+    __version__,
     Volume,
     Structure,
     structure_to_shape_like,
@@ -35,6 +36,10 @@ warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
 def make_parser():
     """Create the command-line argument parser."""
     p = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+
+    p.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
 
     # Positional arguments
     p.add_argument(

--- a/src/powerfit_em/powerfit.py
+++ b/src/powerfit_em/powerfit.py
@@ -1,13 +1,18 @@
 #! ../env/bin/python
 
 
+from functools import partial
 from os.path import splitext, join, abspath
 from time import time
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, FileType
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, BooleanOptionalAction, FileType
 import logging
 from typing import BinaryIO, TextIO
+import warnings
 
 from rich.logging import RichHandler
+from tqdm import TqdmExperimentalWarning
+from tqdm.rich import tqdm as rich_tqdm
+from tqdm.auto import tqdm
 
 from powerfit_em import (
     Volume,
@@ -23,6 +28,9 @@ from powerfit_em.helpers import mkdir_p, write_fits_to_pdb, fisher_sigma
 from powerfit_em.volume import extend, nearest_multiple2357, trim, resample
 
 logger = logging.getLogger(__name__)
+
+warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
+
 
 def make_parser():
     """Create the command-line argument parser."""
@@ -180,6 +188,13 @@ def make_parser():
         metavar="<str>",
         help="Delimiter used in the 'solutions.out' file. For example use ',' or '\\t'. Defaults to fixed width.",
     )
+    p.add_argument(
+        "--progressbar",
+        dest="progressbar",
+        action=BooleanOptionalAction,
+        default=True,
+        help="Show a progress bar during the search.",
+    )
 
     return p
 
@@ -227,6 +242,8 @@ def main():
     mkdir_p(args.directory)
     configure_logging(join(args.directory, "powerfit.log"), args.log_level)
     
+    progress = partial(rich_tqdm, desc="Processing rotations", unit="rot", disable=not args.progressbar)
+
     powerfit(
         target_volume=args.target,
         resolution=args.resolution,
@@ -244,6 +261,7 @@ def main():
         gpu=args.gpu,
         nproc=args.nproc,
         delimiter=args.delimiter,
+        progress=progress
     )
 
 
@@ -263,6 +281,7 @@ def powerfit(target_volume: BinaryIO,
              gpu: str | None =None, 
              nproc: int=1,
              delimiter: str = None,
+             progress: partial[tqdm] = tqdm
              ):
     time0 = time()
     mkdir_p(directory)
@@ -354,7 +373,7 @@ def powerfit(target_volume: BinaryIO,
         logger.info("Requested number of processors: {:d}".format(nproc))
     logger.info("Starting search")
     time1 = time()
-    pf.scan()
+    pf.scan(progress=progress)
     logger.info("Time for search: {:.0f}m {:.0f}s".format(*divmod(time() - time1, 60)))
 
     logger.info("Analyzing results")

--- a/src/powerfit_em/powerfitter.py
+++ b/src/powerfit_em/powerfitter.py
@@ -34,6 +34,9 @@ from ._powerfit import conj_multiply, calc_lcc, dilate_points
 from ._extensions import rotate_grid3d
 
 
+warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
+
+
 class _Counter(object):
     """Thread-safe counter object to follow PowerFit progress"""
 

--- a/src/powerfit_em/powerfitter.py
+++ b/src/powerfit_em/powerfitter.py
@@ -1,20 +1,17 @@
 
 
-from sys import stdout
+from functools import partial
 from os import remove
 from os.path import join, abspath, isdir
 import os.path
-from time import time, sleep
 from multiprocessing import RawValue, Lock, Process, cpu_count
 from string import Template
 import warnings
 
-from tqdm import TqdmExperimentalWarning
-from tqdm.rich import tqdm
-
 import numpy as np
 from numpy.fft import irfftn as np_irfftn, rfftn as np_rfftn
 from scipy.ndimage import binary_erosion, laplace
+from tqdm.auto import tqdm
 try:
     from pyfftw import zeros_aligned, simd_alignment
     from pyfftw.builders import rfftn as rfftn_builder, irfftn as irfftn_builder
@@ -32,9 +29,6 @@ except:
 
 from ._powerfit import conj_multiply, calc_lcc, dilate_points
 from ._extensions import rotate_grid3d
-
-
-warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
 
 
 class _Counter(object):
@@ -80,24 +74,27 @@ class PowerFitter(object):
         else:
             raise ValueError("Directory does not exist.")
 
-    def scan(self):
+    def scan(self, progress: partial[tqdm]):
         if self._queues is None:
-            self._cpu_scan()
+            if self._nproc == 1:
+                self._single_cpu_scan(progress)
+            else:
+                self._multi_cpu_scan(progress)
         else:
-            self._gpu_scan()
+            self._gpu_scan(progress)
 
-    def _gpu_scan(self):
+    def _gpu_scan(self, progress: partial[tqdm]):
         self._corr = GPUCorrelator(self._target.array, self._queues[0],
                 laplace=self._laplace)
 
         self._corr.template = self._template.array
         self._corr.mask = self._mask.array
         self._corr.rotations = self._rotations
-        self._corr.scan()
+        self._corr.scan(progress)
         self._lcc = self._corr.lcc
         self._rot = self._corr.rot
 
-    def _cpu_scan(self):
+    def _multi_cpu_scan(self, progress: partial[tqdm]):
         nrot = self._rotations.shape[0]
         self._nrot_per_job = nrot // self._nproc
         processes = []
@@ -122,7 +119,7 @@ class PowerFitter(object):
         for n in range(self._njobs):
             processes[n].start()
 
-        with tqdm(total=nrot, desc="Processing rotations", unit="rot") as pbar:
+        with progress(total=nrot) as pbar:
             while self._counter.value() < nrot:
                 current_count = self._counter.value()
                 pbar.update(current_count - pbar.n)
@@ -130,6 +127,18 @@ class PowerFitter(object):
         for n in range(self._njobs):
             processes[n].join()
         self._combine()
+
+    def _single_cpu_scan(self, progress):
+        target = self._target
+        laplace = self._laplace
+        correlator = CPUCorrelator(target.array, laplace=laplace)
+        correlator.template = self._template.array
+        correlator.mask = self._mask.array
+        correlator.rotations = self._rotations
+        correlator.scan(progress)
+        self._lcc = correlator.lcc
+        self._rot = correlator.rot
+
 
     @staticmethod
     def _run_correlator_instance(target, template, mask, rotations, laplace,
@@ -314,13 +323,13 @@ class CPUCorrelator(BaseCorrelator):
             self._rfftn = np_rfftn
             self._irfftn = np_irfftn
 
-    def scan(self):
+    def scan(self, progress):
         super(CPUCorrelator, self).scan()
 
         self._lcc.fill(0)
         self._rot.fill(0)
 
-        for n in range(self._rotations.shape[0]):
+        for n in progress(range(self._rotations.shape[0])):
             # rotate template and mask
             self._translational_scan(self._rotations[n])
             # get the indices where the scanned lcc is greater
@@ -510,13 +519,12 @@ if OPENCL:
             self._irfftn(self._ft_ave2, self._ave2)
             self._queue.finish()
 
-        def scan(self):
+        def scan(self, progress: partial[tqdm] = lambda x: x):
             super(GPUCorrelator, self).scan()
 
             self._glcc.fill(0)
             self._grot.fill(0)
-            time0 = time()
-            for n in range(0, self._rotations.shape[0]):
+            for n in progress(range(0, self._rotations.shape[0])):
 
                 rotmat = self._cl_rotations[n]
 
@@ -532,20 +540,9 @@ if OPENCL:
 
                 self._queue.finish()
 
-                # TODO replace with tqdm
-                self._print_progress(n, self._rotations.shape[0], time0)
             self._glcc.get(ary=self._lcc)
             self._grot.get(ary=self._rot)
             self._queue.finish()
-
-        @staticmethod
-        def _print_progress(n, nrot, time0):
-            p_done = (n + 1) / float(nrot) * 100
-            now = time()
-            eta = ((now - time0) / p_done) * (100 - p_done)
-            total = (now - time0) / p_done * (100)
-            stdout.write('{:7.2%} {:.0f}s {:.0f}s       \r'.format(n / float(nrot), eta, total))
-            stdout.flush()
 
         def _generate_kernels(self):
             kernel_values = {'shape_x': self._shape[2],

--- a/src/powerfit_em/volume.py
+++ b/src/powerfit_em/volume.py
@@ -507,7 +507,7 @@ class XPLORParser(object):
 
     def __init__(self, fid):
 
-        if isinstance(fid, file):
+        if isinstance(fid, BufferedReader):
             fname = fid.name
         elif isinstance(fid, str):
             fname = fid


### PR DESCRIPTION
Allow powerfit to be called with API call.

```python
from powerfit_em.powerfit import powerfit

with open('ribosome-KsgA.map', 'rb') as target, open('KsgA.pdb', 'r') as template:
    powerfit(
        target_volume=target,
        resolution=12,
        template_structure=template,
        angle=20,
        nproc=2,
        laplace=True,
        directory='run-as-lib'
    )
```

Also made the output on the terminal nicer

![Screenshot 2025-06-12 142119](https://github.com/user-attachments/assets/59bc00cc-9419-4fcd-8de0-262b841dd88d)

Also allow you to pick which gpu to use with `--gpu <platform>:<device>` for example `--gpu 0:3`
Using `--gpu` will pick first device in first platform and `` will run with cpu.

Also allow you to disable progressbar with `--no-progressbar` cli arg or pass your own tqdm as progress arg of powerfit function.

Fixes #47 in 75fe752038a43aeb96c1d513fbf7eecb2098e7b2 
