### PR TITLE
Reuse rotate_image3d kernel

### DIFF
--- a/src/powerfit_em/powerfitter.py
+++ b/src/powerfit_em/powerfitter.py
@@ -586,6 +586,7 @@ if OPENCL:
                 t = Template(f.read()).substitute(**values)
 
             self._program = cl.Program(ctx, t).build()
+            self._rotate_image3d = self._program.rotate_image3d
             self._gws_rotate_grid3d = (96, 64, 1)
 
         def rotate_grid3d(self, queue, grid, rotmat, out, nearest=False):
@@ -597,7 +598,7 @@ if OPENCL:
                 args = (image, self.sampler_nearest, rotmat, out.data)
             else:
                 args = (image, self.sampler_linear, rotmat, out.data)
-            self._program.rotate_image3d(queue, self._gws_rotate_grid3d, None, *args)
+            self._rotate_image3d(queue, self._gws_rotate_grid3d, None, *args)
 
 
     class grfftn_builder(object):


### PR DESCRIPTION
The rotate_image3d kernel was currently re-retrieved every time it was used.

I knew this wasn't correct because a warning was printed;
```
/home/bart/git/powerfit/src/powerfit_em/powerfitter.py:600: RepeatedKernelRetrieval: Kernel 'rotate_image3d' has been retrieved more than once. Each retrieval creates a new, independent kernel, at possibly 
considerable expense. To avoid the expense, reuse the retrieved kernel instance. To avoid this warning, use cl.Kernel(prg, name).
```

This change sped up a run with many rotations by >25% in my setup (w/ AMD GPU).