### PR TITLE
When progressbar is disabled, don't wait for queue or counter lock

### DIFF
--- a/src/powerfit_em/correlators/cpu.py
+++ b/src/powerfit_em/correlators/cpu.py
@@ -164,10 +164,14 @@ class CPUCorrelator(Correlator):
         self.lcc[ind] = self.lcc_scan[ind]
         self.rot[ind] = n
 
-    def scan(self, progress: partial[tqdm] = lambda x: x):
+    def scan(self, progress: partial[tqdm] | None = None):
         """Scan all provided rotations to find the best fit."""
         self.vars.lcc.fill(0)
         self.vars.rot.fill(0)
 
-        for n in progress(range(0, self.rotations.shape[0])):
+        _range = range(0, self.rotations.shape[0])
+        if progress is not None:
+            _range = progress(_range)
+        
+        for n in _range:
             self.compute_rotation(n, self.rotations[n])

--- a/src/powerfit_em/correlators/gpu.py
+++ b/src/powerfit_em/correlators/gpu.py
@@ -160,14 +160,19 @@ class GPUCorrelator(Correlator):
         self.vars.lcc.get(ary=self.lcc)
         self.vars.rot.get(ary=self.rot)
 
-    def scan(self, progress: partial[tqdm] = lambda x: x):
+    def scan(self, progress: partial[tqdm] | None):
         """Scan all provided rotations to find the best fit."""
         self.vars.lcc.fill(0)
         self.vars.rot.fill(0)
 
-        for n in progress(range(0, self._rotations.shape[0])):
-            self.compute_rotation(n, self._rotations[n])
-            self.queue.finish() # only necessary if we want to track it/s accuratly
+        _range = range(0, self._rotations.shape[0])
+        if progress is None:
+            for n in _range:
+                self.compute_rotation(n, self._rotations[n])
+        else:
+            for n in progress(_range):
+                self.compute_rotation(n, self._rotations[n])
+                self.queue.finish()
 
         self.retrieve_results()
         self.queue.finish()

--- a/src/powerfit_em/correlators/shared.py
+++ b/src/powerfit_em/correlators/shared.py
@@ -191,5 +191,5 @@ class Correlator(ABC):
         self.compute_lcc_score_and_take_best(n)
 
     @abstractmethod
-    def scan(self, progress: partial[tqdm] = lambda x: x):
+    def scan(self, progress: partial[tqdm] | None):
         pass

--- a/src/powerfit_em/powerfit.py
+++ b/src/powerfit_em/powerfit.py
@@ -252,7 +252,9 @@ def main():
     mkdir_p(args.directory)
     configure_logging(join(args.directory, "powerfit.log"), args.log_level)
     
-    progress = partial(rich_tqdm, desc="Processing rotations", unit="rot", disable=not args.progressbar)
+    progress = partial(
+        rich_tqdm, desc="Processing rotations", unit="rot"
+    ) if args.progressbar else None
 
     powerfit(
         target_volume=args.target,
@@ -291,7 +293,7 @@ def powerfit(target_volume: BinaryIO,
              gpu: str | None =None, 
              nproc: int=1,
              delimiter: str = None,
-             progress: partial[tqdm] = tqdm
+             progress: partial[tqdm] | None = tqdm
              ):
     time0 = time()
     mkdir_p(directory)
@@ -382,7 +384,11 @@ def powerfit(target_volume: BinaryIO,
     logger.info("Starting search")
     time1 = time()
     pf.scan(progress=progress)
-    logger.info("Time for search: {:.0f}m {:.0f}s".format(*divmod(time() - time1, 60)))
+    dtime = time() - time1
+    if dtime < 10:
+        logger.info("Time for search: {:.3f} s".format(dtime))
+    else:
+        logger.info("Time for search: {:.0f}m {:.0f}s".format(*divmod(dtime, 60)))
     logger.info("Analyzing results")
     # calculate the molecular volume of the structure
     mv = (

--- a/src/powerfit_em/powerfitter.py
+++ b/src/powerfit_em/powerfitter.py
@@ -101,7 +101,7 @@ class PowerFitter(object):
         else:
             self._gpu_scan(progress)
 
-    def _gpu_scan(self, progress: partial[tqdm]):
+    def _gpu_scan(self, progress: partial[tqdm] | None):
         if OPENCL:
             from powerfit_em.correlators.gpu import GPUCorrelator
         self._corr = GPUCorrelator(

--- a/src/powerfit_em/powerfitter.py
+++ b/src/powerfit_em/powerfitter.py
@@ -46,7 +46,7 @@ def run_correlator_instance(
     laplace: bool,
     jobid: int,
     directory: str,
-    counter: _Counter
+    counter: _Counter | None
 ):
     correlator = CPUCorrelator(
         target.array,
@@ -57,8 +57,9 @@ def run_correlator_instance(
     )
     for n in range(len(rotations)):
         correlator.compute_rotation(n, rotmat=correlator.rotations[n])
-        counter.increment()
-        
+        if counter is not None:
+            counter.increment()
+
     np.save(join(directory, '_lcc_part_{:d}.npy').format(jobid), correlator.lcc)
     np.save(join(directory, '_rot_part_{:d}.npy').format(jobid), correlator.rot)
 
@@ -91,7 +92,7 @@ class PowerFitter(object):
         else:
             raise ValueError("Directory does not exist.")
 
-    def scan(self, progress: partial[tqdm]):
+    def scan(self, progress: partial[tqdm] | None):
         if self._queues is None:
             if self._nproc == 1:
                 self._single_cpu_scan(progress)
@@ -115,11 +116,11 @@ class PowerFitter(object):
         self._lcc = self._corr.lcc
         self._rot = self._corr.rot
 
-    def _multi_cpu_scan(self, progress: partial[tqdm]):
+    def _multi_cpu_scan(self, progress: partial[tqdm] | None):
         nrot = self._rotations.shape[0]
         self._nrot_per_job = nrot // self._nproc
         processes: list[Process] = []
-        self._counter = _Counter()
+        self._counter = None if processes is None else _Counter()
         self._njobs = self._nproc
         if self._queues is not None:
             self._njobs = len(self._queues)
@@ -142,16 +143,17 @@ class PowerFitter(object):
         for id in range(self._njobs):
             processes[id].start()
 
-        with progress(total=nrot) as pbar:
-            while self._counter.value() < nrot:
-                current_count = self._counter.value()
-                pbar.update(current_count - pbar.n)
+        if progress is not None:
+            with progress(total=nrot) as pbar:
+                while self._counter.value() < nrot:
+                    current_count = self._counter.value()
+                    pbar.update(current_count - pbar.n)
         
         for id in range(self._njobs):
             processes[id].join()
         self._combine()
 
-    def _single_cpu_scan(self, progress):
+    def _single_cpu_scan(self, progress: partial[tqdm] | None):
         correlator = CPUCorrelator(
             self._target.array,
             self._template.array,


### PR DESCRIPTION
See title.

The logger now outputs time in the format 1.123s when the search time is <10s.

Fixes #61 