### PR TITLE
Working importlib.resources in python <3.13

### DIFF
--- a/src/powerfit_em/correlators/clkernels.py
+++ b/src/powerfit_em/correlators/clkernels.py
@@ -7,7 +7,7 @@ from pyopencl.elementwise import ElementwiseKernel
 from string import Template
 import importlib.resources
 
-import powerfit_em
+import powerfit_em.correlators
 
 
 class CLKernels(object):
@@ -38,7 +38,7 @@ class CLKernels(object):
                 """
                 )
 
-        t = importlib.resources.read_text(powerfit_em, "correlators/kernels.cl")
+        t = importlib.resources.read_text(powerfit_em.correlators, "kernels.cl")
         t = Template(t).substitute(**values)
 
         self._program = cl.Program(ctx, t).build()

--- a/src/powerfit_em/rotations.py
+++ b/src/powerfit_em/rotations.py
@@ -5,7 +5,7 @@ import importlib.resources
 
 import numpy as np
 
-import powerfit_em
+import powerfit_em.data
 
 
 def euler(angle, axis):
@@ -122,7 +122,7 @@ def proportional_orientations(angle):
             fname = s
 
     # read file
-    infile = importlib.resources.open_binary(powerfit_em, f"data/{fname}")
+    infile = importlib.resources.open_binary(powerfit_em.data, fname)
     quat_weights = np.load(infile)
 
     quat = quat_weights[:, :4]


### PR DESCRIPTION
Fixes #77

Tested with

```shell
uv pip install -e .[opencl]
uv build
# Dev install with Python 3.12
powerfit ~/powerfit-tutorial/ribosome-KsgA.map 13 ~/powerfit-tutorial/KsgA.pdb -a 20 -l -d run --gpu
cd /tmp
# Python 3.13 with sdist
uv venv -p 3.13 py3.13
source py3.13/bin/activate
uv pip install ~/powerfit/dist/powerfit_em-3.0.5.tar.gz[opencl] 
powerfit ~/powerfit-tutorial/ribosome-KsgA.map 13 ~/powerfit-tutorial/KsgA.pdb -a 20 -l -d run --gpu
# Python 3.10 with sdist
uv venv -p 3.10 py3.10
source py3.10/bin/activate
uv pip install ~/powerfit/dist/powerfit_em-3.0.5.tar.gz[opencl] 
powerfit ~/powerfit-tutorial/ribosome-KsgA.map 13 ~/powerfit-tutorial/KsgA.pdb -a 20 -l -d run --gpu
# Skip Python 3.11
# Python 3.12 with bin wheel
uv venv -p 3.12 py3.12
source py3.12/bin/activate
uv pip install ~/powerfit/dist/powerfit_em-3.0.5-cp312-cp312-linux_x86_64.whl[opencl]
powerfit ~/powerfit-tutorial/ribosome-KsgA.map 13 ~/powerfit-tutorial/KsgA.pdb -a 20 -l -d run --gpu
```

