### PR TITLE
Add notes on iGPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Minimal requirements for the CPU version:
 * FFTW3
 * pyFFTW 0.10+
 
-To offload computations to the GPU the following is also required
+To offload computations to a discrete or integrated\* GPU the following is also required
 
 * OpenCL1.1+
 * pyopencl
@@ -40,6 +40,8 @@ Recommended for installation
 
 * git
 * pip
+
+\* _Integrated graphics on CPUs are able to signficantly outperform the native CPU implementation in some cases. This is mostly applicable to Intel devices, see the section [tested platfoms](#tested-platforms)_.
 
 ## Installation
 
@@ -327,10 +329,14 @@ Copyright (c) 2005-2015, Christoph Gohlke
 |MacOSX           | Yes        | Yes       | No  |
 |Windows          | Yes        | Fail      | No  |
 
-The GPU version has been tested on:
+The GPU version has been successfully tested on Linux and with a Docker container for the following devices;
 
-* NVIDIA GeForce GTX 1050 Ti, GeForce RTX 4070 and AMD Radeon RX 7900 XTX on Linux 
-* NVIDIA GeForce GTX 1050 Ti, AMD Radeon RX 7800 XT and AMD Radeon RX 7900 XTX in Docker container
+* NVIDIA GeForce GTX 1050 Ti
+* AMD Radeon RX 7800 XT
+* AMD Radeon RX 7900 XTX
+* Intel Iris Xe Graphics (on a Core i7-1185G7)
+
+The integrated graphics of AMD Ryzen CPUs do not officially support OpenCL. If they do seem available in PyOpenCL be aware that this [may lead to incorrect results](https://github.com/haddocking/powerfit/issues/76).
 
 ## Development
 


### PR DESCRIPTION
It turned out that running powerfit on my laptop's (Intel) integrated graphics has improved performance vs. the CPU implementation (#71). This is valuable information for users.

However, my PC's Ryzen 7 CPU also seemed to perform well but with incorrect results. OpenCL is not officially supported for this CPU's integrated graphics, or at all for any AMD CPU since 2018.

I have added notes on this in the requirements and tested platform sections of the readme.