### PR TITLE
Allow for concurrect openCL queues, reusing GPU correlators

### DIFF
--- a/src/powerfit_em/analyzer.py
+++ b/src/powerfit_em/analyzer.py
@@ -4,8 +4,8 @@ from scipy.ndimage import label, maximum_position
 class Analyzer(object):
 
 
-    def __init__(self, corr, rotmat, rotmat_ind, steps=5, voxelspacing=1,
-                 origin=(0, 0, 0), z_sigma=1):
+    def __init__(self, corr, rotmat, rotmat_ind, steps=5, voxelspacing=1.0,
+                 origin=(0, 0, 0), z_sigma=1.0):
         self._corr = corr
         self._rotmat = rotmat
         self._rotmat_ind = rotmat_ind

--- a/src/powerfit_em/correlators/cpu.py
+++ b/src/powerfit_em/correlators/cpu.py
@@ -45,7 +45,7 @@ def zeros_array(shape: tuple[int], dtype: npt.DTypeLike, fftw: bool) -> np.ndarr
 
 
 def init_cpu_vars(
-    target: np.ndarray, mask: np.ndarray, laplace: bool, fftw: bool,
+    target: np.ndarray, laplace: bool, fftw: bool,
 )-> tuple[Vars[np.ndarray, np.ndarray], VarsFT[np.ndarray]]:
     """Initialize all CPU variables on the specified queue."""
 
@@ -55,7 +55,7 @@ def init_cpu_vars(
     vars = Vars(
         target = _t.astype(f32),
         template = zeros_array(target.shape, f32, fftw),
-        mask = mask.astype(f32),
+        mask = zeros_array(target.shape, f32, fftw),
         lcc_mask = lcc_mask.astype(np.uint8),
         target2 = zeros_array(target.shape, f32, fftw),
         rot_template = zeros_array(target.shape, f32, fftw),
@@ -109,17 +109,15 @@ class CPUCorrelator(Correlator):
         """
         self.target: np.ndarray = target / target.max()
         self.laplace = laplace
-        self.mask = mask
         self.rotations = rotations
-        self.norm_factor = get_normalization_factor(mask)
 
-        self.vars, self.vars_ft = init_cpu_vars(self.target, mask, self.laplace, fftw)
+        self.vars, self.vars_ft = init_cpu_vars(self.target, self.laplace, fftw)
     
         self.lcc_scan = np.zeros(self.target.shape, dtype=f32)
         self.lcc = np.zeros(self.target.shape, dtype=f32)
         self.rot = np.zeros(self.target.shape, dtype=i32)
 
-        self.set_template(template)
+        self.set_template(template, mask)
 
         # set methods in the same was as GPUCorrelator implementation;
         self.conj_multiply = lambda a,b,c: np.multiply(np.conjugate(a), b, out=c)
@@ -132,6 +130,9 @@ class CPUCorrelator(Correlator):
 
     def _set_template_var(self, template: np.ndarray):
         self.vars.template = template.astype(f32)
+
+    def _set_mask_var(self, mask: np.ndarray):
+        self.vars.mask = mask.astype(f32)
 
     def rotate_grids(self, rotmat: np.ndarray):
         """Rotate the template and mask using the rotational matrix."""

--- a/src/powerfit_em/correlators/gpu.py
+++ b/src/powerfit_em/correlators/gpu.py
@@ -14,7 +14,7 @@ from powerfit_em.correlators.shared import Correlator, Vars, VarsFT, get_ft_shap
 
 
 def init_gpu_vars(
-    queue: cl.CommandQueue, target: np.ndarray, mask: np.ndarray, laplace: bool,
+    queue: cl.CommandQueue, target: np.ndarray, laplace: bool,
 ) -> tuple[Vars[ClArray, Image], VarsFT[ClArray]]:
     """Initialize all GPU variables on the specified queue."""
     lcc_mask = get_lcc_mask(target)
@@ -23,7 +23,7 @@ def init_gpu_vars(
     gpu_vars = Vars(
         target = cl_array.to_device(queue, _t.astype(f32)),
         template = cl.image_from_array(queue.context, zeros),  # template is set through separate method
-        mask = cl.image_from_array(queue.context, mask.astype(f32)),
+        mask = cl.image_from_array(queue.context, zeros),  # mask is set through separate method
         lcc_mask = cl_array.to_device(queue, lcc_mask.astype(i32)),
         target2 = cl_array.to_device(queue, zeros),
         rot_template = cl_array.to_device(queue, zeros),
@@ -108,18 +108,16 @@ class GPUCorrelator(Correlator):
         self.laplace = laplace
         self.mask = mask
         self.queue = queue
+        self.norm_factor = 0.0  # to be set by set_template
 
         self._rotations = transform_rotations(rotations)
 
-        # Precompute the normalization factor for use in the LCC computing kernel
-        self.norm_factor = get_normalization_factor(mask)
-
-        self.vars, self.vars_ft = init_gpu_vars(queue, self.target, mask, self.laplace)
+        self.vars, self.vars_ft = init_gpu_vars(queue, self.target, self.laplace)
 
         self.lcc = np.zeros(self.target.shape, dtype=np.float32)
         self.rot = np.zeros(self.target.shape, dtype=np.int32)
 
-        self.set_template(template)
+        self.set_template(template, mask)
 
         self.cl_kernels = generate_kernels(queue, self.target)
         self.conj_multiply = self.cl_kernels.conj_multiply
@@ -130,6 +128,9 @@ class GPUCorrelator(Correlator):
 
     def _set_template_var(self, template: np.ndarray):
         self.vars.template = cl.image_from_array(self.vars.template.context, template.astype(f32))
+
+    def _set_mask_var(self, mask: np.ndarray):
+        self.vars.mask = cl.image_from_array(self.vars.mask.context, mask.astype(f32))
 
     def rotate_grids(self, rotmat: np.ndarray):
         """Rotate the template and mask using the rotational matrix."""
@@ -159,6 +160,7 @@ class GPUCorrelator(Correlator):
         """Retrieve the results from the GPU."""
         self.vars.lcc.get(ary=self.lcc)
         self.vars.rot.get(ary=self.rot)
+        self.queue.finish()
 
     def scan(self, progress: partial[tqdm] | None):
         """Scan all provided rotations to find the best fit."""
@@ -173,6 +175,3 @@ class GPUCorrelator(Correlator):
             for n in progress(_range):
                 self.compute_rotation(n, self._rotations[n])
                 self.queue.finish()
-
-        self.retrieve_results()
-        self.queue.finish()

--- a/src/powerfit_em/correlators/shared.py
+++ b/src/powerfit_em/correlators/shared.py
@@ -93,7 +93,6 @@ class Correlator(ABC):
     square: Callable
     laplace: bool
     target: np.ndarray
-    mask: np.ndarray
     lcc: np.ndarray
     rot: np.ndarray
 
@@ -107,7 +106,11 @@ class Correlator(ABC):
         """Set the Vars.template variable in-place."""
         pass
 
-    def set_template(self, template: np.ndarray):
+    @abstractmethod
+    def _set_mask_var(self, mask: np.ndarray):
+        """Set the Vars.mask variable in-place."""
+
+    def set_template(self, template: np.ndarray, mask: np.ndarray):
         """Set the template structure that you want to fit in the target density.
 
         Can be used to try to fit a different template to the same target structure
@@ -122,9 +125,13 @@ class Correlator(ABC):
 
         if self.laplace:
             template = laplace_filter(template, mode='wrap')
-        
-        template = normalize_template(template, self.mask)
+
+        # Precompute the normalization factor for use in the LCC computing kernel
+        self.norm_factor = get_normalization_factor(mask)
+
+        template = normalize_template(template, mask)
         self._set_template_var(template)
+        self._set_mask_var(template)
 
         # Reset lcc and rot values after (re)setting the template
         self.lcc[:] = 0.0

--- a/src/powerfit_em/powerfit.py
+++ b/src/powerfit_em/powerfit.py
@@ -3,6 +3,7 @@
 
 from functools import partial
 from os.path import splitext, join, abspath
+from pathlib import Path
 from time import time
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, BooleanOptionalAction, FileType
 import logging
@@ -56,8 +57,9 @@ def make_parser():
     p.add_argument("resolution", type=float, help="Resolution of map in angstrom")
     p.add_argument(
         "template",
+        nargs="+",
         type=FileType("r"),
-        help="Atomic model to be fitted in the density. "
+        help="Atomic model(s) to be fitted in the density. "
         "Format should either be PDB or mmCIF",
     )
 
@@ -256,10 +258,14 @@ def main():
         rich_tqdm, desc="Processing rotations", unit="rot"
     ) if args.progressbar else None
 
+    if len(set(t.name for t in args.template)) != len(args.template):
+        msg = "Non-unique templates provided. Please check your input."
+        raise ValueError(msg)
+
     powerfit(
         target_volume=args.target,
         resolution=args.resolution,
-        template_structure=args.template,
+        template_structures=args.template,
         angle=args.angle,
         laplace=args.laplace,
         core_weighted=args.core_weighted,
@@ -277,26 +283,75 @@ def main():
     )
 
 
-def powerfit(target_volume: BinaryIO,
-             resolution: float,
-             template_structure: TextIO,
-             angle: float=10,
-             laplace: bool=False,
-             core_weighted: bool=False,
-             no_resampling: bool=False,
-             resampling_rate: float=2,
-             no_trimming: bool=False,
-             trimming_cutoff: float | None=None,
-             chain: str | None =None,
-             directory: str='.',
-             num: int=10,
-             gpu: str | None =None, 
-             nproc: int=1,
-             delimiter: str = None,
-             progress: partial[tqdm] | None = tqdm
-             ):
+def compute_template_mask_volumes(
+    template_structures: list[TextIO],
+    target: Volume,
+    resolution: float,
+    logger: logging.Logger | None = None,
+    chain: str | None = None,
+) -> tuple[list[Volume], list[Volume], list[Structure]]:
+    """Compute the Volumes of each template structure, along with the associated masks."""
+    templates: list[Volume] = []
+    masks: list[Volume] = []
+    structures: list[Structure] = []
+    for template in template_structures:
+        # Read in structure or high-resolution map
+        if logger is not None:
+            logger.info("Template file read from: {:s}".format(abspath(template.name)))
+        structure = Structure.fromfile(template)
+        if chain is not None:
+            if logger is not None:
+                logger.info("Selecting chains: " + chain)
+            structure = structure.select("chain", chain.split(","))
+        if structure.data.size == 0:
+            raise ValueError("No atoms were selected.")
+
+        # Move structure to origin of density
+        structure.translate(target.origin - structure.coor.mean(axis=1))
+        template = structure_to_shape_like(
+            target,
+            structure.coor,
+            resolution=resolution,
+            weights=structure.atomnumber,
+            shape="vol",
+        )
+        mask = structure_to_shape_like(
+            target, structure.coor, resolution=resolution, shape="mask"
+        )
+        templates.append(template)
+        masks.append(mask)
+        structures.append(structure)
+    return templates, masks, structures
+
+
+def powerfit(
+    target_volume: BinaryIO,
+    resolution: float,
+    template_structures: list[TextIO],
+    angle: float=10,
+    laplace: bool=False,
+    core_weighted: bool=False,
+    no_resampling: bool=False,
+    resampling_rate: float=2,
+    no_trimming: bool=False,
+    trimming_cutoff: float | None=None,
+    chain: str | None =None,
+    directory: str='.',
+    num: int=10,
+    gpu: str | None =None, 
+    nproc: int=1,
+    delimiter: str | None = None,
+    progress: partial[tqdm] | None = tqdm,
+):
     time0 = time()
     mkdir_p(directory)
+
+    if len(template_structures) > 1:
+        template_dirs = [Path(directory) / Path(t.name).name for t in template_structures]
+        for d in template_dirs:
+            d.mkdir(exist_ok=True)
+    else:
+        template_dirs = [directory]
 
     # Get GPU queue if requested
     queues = None
@@ -317,7 +372,9 @@ def powerfit(target_volume: BinaryIO,
         if device_idx >= len(devices):
             raise RuntimeError(f"Requested OpenCL device {device_idx} not found on platform {platform_idx}.")
         context = cl.Context(devices=[devices[device_idx]])
-        queues = [cl.CommandQueue(context, device=devices[device_idx])]
+        queues = []
+        for _ in range(nproc):
+            queues.append(cl.CommandQueue(context, device=devices[device_idx]))
 
     logger.info("Target file read from: {:s}".format(abspath(target_volume.name)))
     target = Volume.fromfile(target_volume)
@@ -340,28 +397,10 @@ def powerfit(target_volume: BinaryIO,
     target = extend(target, extended_shape)
     logger.info(("Shape after extending:" + " {:d}" * 3).format(*target.shape))
 
-    # Read in structure or high-resolution map
-    logger.info("Template file read from: {:s}".format(abspath(template_structure.name)))
-    structure = Structure.fromfile(template_structure)
-    if chain is not None:
-        logger.info("Selecting chains: " + chain)
-        structure = structure.select("chain", chain.split(","))
-    if structure.data.size == 0:
-        raise ValueError("No atoms were selected.")
-
-    # Move structure to origin of density
-    structure.translate(target.origin - structure.coor.mean(axis=1))
-    template = structure_to_shape_like(
-        target,
-        structure.coor,
-        resolution=resolution,
-        weights=structure.atomnumber,
-        shape="vol",
+    templates, masks, structures = compute_template_mask_volumes(
+        template_structures, target, resolution, logger, chain
     )
-    mask = structure_to_shape_like(
-        target, structure.coor, resolution=resolution, shape="mask"
-    )
-
+    
     # Read in the rotations to sample
     logger.info("Reading in rotations.")
     q, w, degree = proportional_orientations(angle)
@@ -371,57 +410,84 @@ def powerfit(target_volume: BinaryIO,
 
     # Apply core-weighted mask if requested
     if core_weighted:
-        logger.info("Calculating core-weighted mask.")
-        mask.array = determine_core_indices(mask.array)
+        logger.info("Calculating core-weighted mask(s).")
+        for mask in masks:
+            mask.array = determine_core_indices(mask.array)
 
-    pf = PowerFitter(target, rotmat, template, mask, queues, laplace=laplace)
-    pf._nproc = nproc
-    pf.directory = directory
-    if gpu:
-        logger.info("Using GPU-accelerated search.")
-    else:
-        logger.info("Requested number of processors: {:d}".format(nproc))
-    logger.info("Starting search")
-    time1 = time()
-    pf.scan(progress=progress)
-    dtime = time() - time1
-    if dtime < 10:
-        logger.info("Time for search: {:.3f} s".format(dtime))
-    else:
-        logger.info("Time for search: {:.0f}m {:.0f}s".format(*divmod(dtime, 60)))
-    logger.info("Analyzing results")
-    # calculate the molecular volume of the structure
-    mv = (
-        structure_to_shape_like(
-            target,
-            structure.coor,
-            resolution=resolution,
-            radii=structure.rvdw,
-            shape="mask",
-        ).array.sum()
-        * target.voxelspacing**3
-    )
-    z_sigma = fisher_sigma(mv, resolution)
-    analyzer = Analyzer(
-        pf._lcc,
-        rotmat,
-        pf._rot,
-        voxelspacing=target.voxelspacing,
-        origin=target.origin,
-        z_sigma=z_sigma,
-    )
+    # from IPython import embed; embed(); quit()
+    setups = list(zip(templates, masks, structures, template_dirs, strict=True))
+    pfs: list[PowerFitter] = []
+    while len(setups) > 0:
+        # No reuse required for CPU
+        if queues is None:
+            template, mask, structure, output_dir = setups.pop()
+            pfs = [PowerFitter(target, rotmat, structure, template, mask, queues, str(output_dir), nproc, laplace)]
+        # Setup <nproc> queues for GPU
+        else:
+            for n in range(len(queues)):
+                template, mask, structure, output_dir = setups.pop()
+                if len(pfs) <= n: # First time initialize the powerfitters
+                    pfs.append(PowerFitter(target, rotmat, structure, template, mask, queues[n], str(output_dir), nproc, laplace))
+                else: # Afterwards reuse powerfitters
+                    pfs[n].set_template(template, mask, structure)
 
-    logger.info("Writing solutions to file.")
-    Volume(pf._lcc, target.voxelspacing, target.origin).tofile(
-        join(directory, "lcc.mrc")
-    )
-    analyzer.tofile(join(directory, "solutions.out"), delimiter=delimiter)
+        if gpu:
+            logger.info(f"Using GPU-accelerated search, using {nproc} queues.")
+        else:
+            logger.info(f"Requested number of processors: {nproc}")
+        logger.info("Starting search")
+        if len(templates) > 1:
+            logger.info(f"Correlating {len(templates)} template structures.")
+        time1 = time()
 
-    logger.info("Writing PDBs to file.")
-    n = min(num, len(analyzer.solutions))
-    write_fits_to_pdb(
-        structure, analyzer.solutions[:n], basename=join(directory, "fit")
-    )
+        for pf in pfs:
+            pf.scan(progress=progress)
+
+        # GPU retrieval is blocking; let scans run in parallel queues before retrieving.
+        for pf in pfs:
+            pf.retrieve_results()
+
+        dtime = time() - time1
+        if dtime < 10:
+            logger.info("Time for search: {:.3f} s".format(dtime))
+        else:
+            logger.info("Time for search: {:.0f}m {:.0f}s".format(*divmod(dtime, 60)))
+
+        logger.info("Analyzing results")
+
+        for pf in pfs:
+            # calculate the molecular volume of the structure
+            mv = (
+                structure_to_shape_like(
+                    target,
+                    pf.structure.coor,
+                    resolution=resolution,
+                    radii=pf.structure.rvdw,
+                    shape="mask",
+                ).array.sum()
+                * target.voxelspacing**3
+            )
+            z_sigma = fisher_sigma(mv, resolution)
+            analyzer = Analyzer(
+                pf._lcc,
+                rotmat,
+                pf._rot,
+                voxelspacing=target.voxelspacing,
+                origin=target.origin,
+                z_sigma=z_sigma,
+            )
+
+            logger.info("Writing solutions to file.")
+            Volume(pf._lcc, target.voxelspacing, target.origin).tofile(
+                join(pf._directory, "lcc.mrc")
+            )
+            analyzer.tofile(join(pf._directory, "solutions.out"), delimiter=delimiter)
+
+            logger.info("Writing PDBs to file.")
+            n = min(num, len(analyzer.solutions))
+            write_fits_to_pdb(
+                pf.structure, analyzer.solutions[:n], basename=join(pf._directory, "fit")
+            )
 
     logger.info("Total time: {:.0f}m {:.0f}s".format(*divmod(time() - time0, 60)))
 

--- a/src/powerfit_em/powerfitter.py
+++ b/src/powerfit_em/powerfitter.py
@@ -9,6 +9,9 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from powerfit_em.correlators.cpu import CPUCorrelator
+from powerfit_em.correlators.gpu import GPUCorrelator
+from powerfit_em.correlators.shared import Correlator
+from powerfit_em.structure import Structure
 from powerfit_em.volume import Volume
 try:
     import pyfftw as _
@@ -70,27 +73,27 @@ class PowerFitter(object):
     """
 
     def __init__(
-        self, target: Volume, rotations: np.ndarray, template: Volume, mask: Volume, queues, laplace: bool = False
+        self,
+        target: Volume,
+        rotations: np.ndarray,
+        structure: Structure,
+        template: Volume,
+        mask: Volume,
+        queues,
+        directory = abspath('./'),
+        nproc: int = 1,
+        laplace: bool = False
     ):
         self._target = target
         self._rotations = rotations
+        self.structure = structure
         self._template = template
         self._mask = mask
         self._queues = queues
-        self._nproc = 1
-        self._directory = abspath('./')
+        self._nproc = nproc
+        self._directory = directory
         self._laplace = laplace
-
-    @property
-    def directory(self):
-        return self._directory
-
-    @directory.setter
-    def directory(self, directory):
-        if isdir(directory):
-            self._directory = abspath(directory)
-        else:
-            raise ValueError("Directory does not exist.")
+        self._corr: Correlator | None = None
 
     def scan(self, progress: partial[tqdm] | None):
         if self._queues is None:
@@ -101,6 +104,22 @@ class PowerFitter(object):
         else:
             self._gpu_scan(progress)
 
+    def retrieve_results(self):
+        if isinstance(self._corr, GPUCorrelator):
+            self._corr.retrieve_results()
+            self._lcc = self._corr.lcc
+            self._rot = self._corr.rot
+
+    def set_template(self, template: Volume, mask: Volume, structure: Structure):
+        self.structure = structure
+        if self._corr is not None:
+            self._corr.set_template(template.array, mask.array)
+            self._lcc = np.zeros(0, dtype=self._lcc.dtype)
+            self._rot = np.zeros(0, dtype=self._rot.dtype)
+        else:
+            msg = "Correlator undefined. First do a scan before trying to (re)set the template."
+            raise ValueError(msg)
+
     def _gpu_scan(self, progress: partial[tqdm] | None):
         if OPENCL:
             from powerfit_em.correlators.gpu import GPUCorrelator
@@ -109,12 +128,10 @@ class PowerFitter(object):
             self._template.array,
             self._rotations,
             self._mask.array,
-            self._queues[0],
+            self._queues,
             self._laplace,
         )
         self._corr.scan(progress)
-        self._lcc = self._corr.lcc
-        self._rot = self._corr.rot
 
     def _multi_cpu_scan(self, progress: partial[tqdm] | None):
         nrot = self._rotations.shape[0]


### PR DESCRIPTION
ToDo:

- [ ] Investigate performance
- [ ] Clean up/refactor code (if performance improvement is deemed significant enough)

Concurrent OpenCL queues seem to work;
<img width="1654" height="345" alt="image" src="https://github.com/user-attachments/assets/4a0b6fc7-60ff-48a5-9423-7c6499eeb8d2" />

On my machine I get 2 concurrent queues, with more queues they are waiting for each other to be finished.