### PR TITLE
Report table

### DIFF
--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -174,7 +174,11 @@ def _read_solutions(path: Path, delimiter: str | None = None) -> list[dict]:
 
 
 def generate_html(
-    target_path: Path, iso: Iso, state_path: Path, options: dict[str, Any]
+    target_path: Path,
+    iso: Iso,
+    state_path: Path,
+    options: dict[str, Any],
+    solutions_table: str,
 ):
     # template was copied from molviewspec.molstar_widgets.STORIES_TEMPLATE and heavily modified
     template = Template(
@@ -201,7 +205,6 @@ def generate_html(
                         min-width: 100vw;
                         display: flex;
                         flex-direction: column;
-                        background: #fff;
                     }
 
                     header {
@@ -250,6 +253,32 @@ def generate_html(
                         gap: 16px;
                         height: 100%;
                         box-sizing: border-box;
+                    }
+               
+                    #solutions-table table{
+                        border-collapse: collapse;
+                        border: 1px solid #ccc;
+                        margin: 1rem;
+               
+                        th, td {
+                            border: 1px solid rgb(160 160 160);
+                            padding: 8px 10px;
+                        }
+                    }
+               
+                    .close-sigma-lt1 {
+                        background-color: #b2e5b2; /* lighter green */
+                        font-weight: bold;
+                    }   
+                    .close-sigma-1to2 {
+                        background-color: #c8f7c8; /* lighter medium green */
+                        font-weight: bold;
+                    }
+                    .close-sigma-2to3 {
+                        background-color: #e6ffe6; /* very light green */
+                        font-weight: bold;
+                    }
+                    .close-sigma-gt3 {
                     }
 
                     @media (orientation:portrait),
@@ -315,6 +344,9 @@ def generate_html(
                         <mvs-stories-snapshot-markdown style="flex-grow: 1;" />
                     </div>
                 </div>
+               <div id="solutions-table">
+               ${solutions}
+               </div>
                 <script>
                     mvsStories.loadFromURL('${state}', { format: 'mvsj' });
 
@@ -398,6 +430,7 @@ def generate_html(
     li_options = "\n".join(
         [f"<li>{key}: {value}</li>" for key, value in options.items()]
     )
+
     return template.safe_substitute(
         state=state_path.name,
         target=target_path.name,
@@ -407,7 +440,48 @@ def generate_html(
         iso_step=round(iso.step, 2),
         options=li_options,
         molstar_version="4.18.0",
+        solutions=solutions_table,
     )
+
+
+def generated_table(solutions: list[dict[str, Any]]) -> str:
+    if not solutions:
+        return "<p>No solutions found.</p>"
+    table = dedent("""\
+        <table>
+        <thead>
+          <tr>
+            <th>Rank</th>
+            <th>Cross correlation score</th>
+            <th>Fisher z-score</th>
+            <th>Relative z-score (z-score/&alpha;)</th>
+            <th>Sigma difference (z<sub>1</sub>-z<sub>N</sub>/&alpha;)</th>
+          </tr>
+        </thead>
+        <tbody>
+        """)
+    best_z = float(solutions[0]["Fish-z"])
+    for solution in solutions:
+        sigma_dif = round(float(solution["rel-z"]) - best_z, 3)
+        if sigma_dif < 1:
+            class_name = "close-sigma-lt1"
+        elif sigma_dif < 2:
+            class_name = "close-sigma-1to2"
+        elif sigma_dif < 3:
+            class_name = "close-sigma-2to3"
+        else:
+            class_name = "close-sigma-gt3"
+        table += dedent(f"""\
+            <tr class="{class_name}">
+              <td>{solution["rank"]}</td>
+              <td>{solution["cc"]}</td>
+              <td>{solution["Fish-z"]}</td>
+              <td>{solution["rel-z"]}</td>
+              <td>{sigma_dif}</td>
+            </tr>
+        """)
+    table += "</tbody></table>\n"
+    return table
 
 
 def generate_report(
@@ -427,6 +501,7 @@ def generate_report(
         target: Target volume file name.
         num: Number of fits to include in the report.
         delimiter: Delimiter used in the solutions file. If None, the report raise an error.
+        options: Options used for fitting, to include in the report.
     """
     run_dir = Path(directory)
 
@@ -474,8 +549,10 @@ def generate_report(
     state_path = run_dir / "state.mvsj"
     state_path.write_text(state.dumps(indent=2))
 
+    solutions_table = generated_table(solutions[:num])
+
     report = run_dir / "report.html"
-    body = generate_html(target_path, iso, state_path, options)
+    body = generate_html(target_path, iso, state_path, options, solutions_table)
     report.write_text(body)
 
     rel_report = Path(os.path.relpath(report, Path.cwd()))

--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -112,7 +112,7 @@ def _create_snapshot_description(solution: dict[str, Any]) -> str:
             - Fitted model: [{fitted_model_file.name}]({fitted_model_file.name})
             - Cross correlation score: {solution["cc"]}
             - Fisher z-score: {solution["Fish-z"]}
-            - Relative z-score (z-score/α: {solution["rel-z"]}
+            - Relative z-score (z-score/α): {solution["rel-z"]}
             - Sigma difference (z₁-zₙ/α): {solution["sigma_dif"]}
             - Translation: {translation}
             - Rotation: {rotation}
@@ -274,7 +274,7 @@ def generate_html(
                         .close-sigma-lt1 {
                             background-color: #b2e5b2; /* lighter green */
                             font-weight: bold;
-                        }   
+                        }
                         .close-sigma-1to2 {
                             background-color: #c8f7c8; /* lighter medium green */
                             font-weight: bold;
@@ -298,7 +298,7 @@ def generate_html(
                             cursor: pointer;
                             box-sizing: border-box
                         }
-                    }            
+                    }
 
                     @media (orientation:portrait),
                     (max-width: 900px) {

--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -254,32 +254,47 @@ def generate_html(
                         height: 100%;
                         box-sizing: border-box;
                     }
-               
-                    #solutions-table table{
-                        border-collapse: collapse;
-                        border: 1px solid #ccc;
-                        margin: 1rem;
-               
-                        th, td {
+
+                    #solutions-table {
+                        table {
+                            border-collapse: collapse;
+                            border: 1px solid #ccc;
+                            margin: 1rem;
+
+                            th, td {
                             border: 1px solid rgb(160 160 160);
                             padding: 8px 10px;
                         }
-                    }
-               
-                    .close-sigma-lt1 {
-                        background-color: #b2e5b2; /* lighter green */
-                        font-weight: bold;
-                    }   
-                    .close-sigma-1to2 {
-                        background-color: #c8f7c8; /* lighter medium green */
-                        font-weight: bold;
-                    }
-                    .close-sigma-2to3 {
-                        background-color: #e6ffe6; /* very light green */
-                        font-weight: bold;
-                    }
-                    .close-sigma-gt3 {
-                    }
+                        .close-sigma-lt1 {
+                            background-color: #b2e5b2; /* lighter green */
+                            font-weight: bold;
+                        }   
+                        .close-sigma-1to2 {
+                            background-color: #c8f7c8; /* lighter medium green */
+                            font-weight: bold;
+                        }
+                        .close-sigma-2to3 {
+                            background-color: #e6ffe6; /* very light green */
+                            font-weight: bold;
+                        }
+                        .close-sigma-gt3 {
+                        }
+                        button {
+                            display: inline-block;
+                            padding: 0.25rem 0.5rem;
+                            text-align: center;
+                            font-size: 11px;
+                            font-weight: 600;
+                            letter-spacing: .1rem;
+                            text-transform: uppercase;
+                            text-decoration: none;
+                            white-space: nowrap;
+                            border-radius: 4px;
+                            border: 1px solid #bbb;
+                            cursor: pointer;
+                            box-sizing: border-box
+                        }
+                    }            
 
                     @media (orientation:portrait),
                     (max-width: 900px) {
@@ -421,6 +436,19 @@ def generate_html(
                             slider.value = currentIsoValue;
                         }
                     });
+               
+                    function jumpToSnapshot(key) {
+                        const context = mvsStories.getContext();
+                        const model = context.state.viewers.value[0].model;
+                        model.plugin?.managers.snapshot.entryMap.forEach((entry, entryId) => {
+                            if (entry.key === key) {
+                                const snapshot = model.plugin?.managers.snapshot.setCurrent(entryId);
+                                if (snapshot) {
+                                    model.plugin.state.setSnapshot(snapshot);
+                                }
+                            }
+                        })
+                    }
                 </script>
             </body>
 
@@ -456,6 +484,7 @@ def generated_table(solutions: list[dict[str, Any]]) -> str:
             <th>Fisher z-score</th>
             <th>Relative z-score (z-score/&alpha;)</th>
             <th>Sigma difference (z<sub>1</sub>-z<sub>N</sub>/&alpha;)</th>
+            <th>Visualize</th>
           </tr>
         </thead>
         <tbody>
@@ -478,6 +507,7 @@ def generated_table(solutions: list[dict[str, Any]]) -> str:
               <td>{solution["Fish-z"]}</td>
               <td>{solution["rel-z"]}</td>
               <td>{sigma_dif}</td>
+              <td><button onclick="jumpToSnapshot('fit_{solution["rank"]}')">View</button></td>
             </tr>
         """)
     table += "</tbody></table>\n"

--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -268,8 +268,9 @@ def generate_html(
                             margin: 1rem;
 
                             th, td {
-                            border: 1px solid rgb(160 160 160);
-                            padding: 8px 10px;
+                                border: 1px solid rgb(160 160 160);
+                                padding: 8px 10px;
+                            }
                         }
                         .close-sigma-lt1 {
                             background-color: #b2e5b2; /* lighter green */
@@ -282,8 +283,6 @@ def generate_html(
                         .close-sigma-2to3 {
                             background-color: #e6ffe6; /* very light green */
                             font-weight: bold;
-                        }
-                        .close-sigma-gt3 {
                         }
                         button {
                             display: inline-block;
@@ -442,7 +441,7 @@ def generate_html(
                             slider.value = currentIsoValue;
                         }
                     });
-               
+
                     function jumpToSnapshot(key) {
                         const context = mvsStories.getContext();
                         const model = context.state.viewers.value[0].model;
@@ -455,6 +454,52 @@ def generate_html(
                             }
                         })
                     }
+
+                    function updateButtonStates(currentKey) {
+                        // Enable all buttons first
+                        document.querySelectorAll('#solutions-table button').forEach(button => {
+                            button.disabled = false;
+                            button.style.opacity = '1';
+                            button.style.cursor = 'pointer';
+                            button.title = 'View this solution in 3D viewer';
+                        });
+
+                        // Disable the button for the current snapshot
+                        if (currentKey) {
+                            const currentButton = document.querySelector(`#solutions-table button[data-snapshot-key="${currentKey}"]`);
+                            if (currentButton) {
+                                currentButton.disabled = true;
+                                currentButton.style.opacity = '0.5';
+                                currentButton.style.cursor = 'not-allowed';
+                                currentButton.title = 'This solution is currently displayed';
+                            }
+                        }
+                    }
+
+                    function setupSnapshotListener() {
+                        const context = mvsStories.getContext();
+                        if (!context?.state?.viewers?.value?.[0]?.model) {
+                            // Retry after a short delay if context is not ready
+                            setTimeout(setupSnapshotListener, 100);
+                            return;
+                        }
+
+                        const model = context.state.viewers.value[0].model;
+                        const plugin = model.plugin;
+
+                        if (plugin?.managers?.snapshot) {
+                            // Update button states when snapshot changes
+                            plugin.managers.snapshot.subscribe(plugin.managers.snapshot.events.changed, (newState) => {
+                                const key = plugin.managers.snapshot.current.key;
+                                updateButtonStates(key);
+                            });
+
+                            // Set initial state
+                            const initialKey = plugin.managers.snapshot.current.key;
+                            updateButtonStates(initialKey);
+                        }
+                    }
+                    setupSnapshotListener();
                 </script>
             </body>
 
@@ -490,7 +535,7 @@ def generated_table(solutions: list[dict[str, Any]]) -> str:
             <th>Fisher z-score</th>
             <th>Relative z-score (z-score/&alpha;)</th>
             <th>Sigma difference (z<sub>1</sub>-z<sub>N</sub>/&alpha;)</th>
-            <th>Visualize</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -505,6 +550,7 @@ def generated_table(solutions: list[dict[str, Any]]) -> str:
             class_name = "close-sigma-2to3"
         else:
             class_name = "close-sigma-gt3"
+        snapshot_key = f"fit_{solution['rank']}"
         table += dedent(f"""\
             <tr class="{class_name}">
               <td>{solution["rank"]}</td>
@@ -512,7 +558,7 @@ def generated_table(solutions: list[dict[str, Any]]) -> str:
               <td>{solution["Fish-z"]}</td>
               <td>{solution["rel-z"]}</td>
               <td>{sigma_dif}</td>
-              <td><button onclick="jumpToSnapshot('fit_{solution["rank"]}')">View</button></td>
+              <td><button data-snapshot-key="{snapshot_key}" onclick="jumpToSnapshot('{snapshot_key}')">View in 3D</button></td>
             </tr>
         """)
     table += "</tbody></table>\n"

--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -485,3 +485,64 @@ def generate_report(
         f"`python3 -m http.server -d {rel_run_dir}`. "
         "Open http://localhost:8000/report.html in a web browser to view the results."
     )
+
+
+if __name__ == "__main__":
+    import argparse
+    from argparse import FileType
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=dedent("""\
+            Generate report.html from fitting results.
+                           
+            Example usage:
+            
+            powerfit ribosome-KsgA.map 13 KsgA.pdb -d run -n 20 --delimiter , -a 20 -l
+            # Later generate report.html with
+            python3 -m powerfit_em.report run ribosome-KsgA.map -n 20 --delimiter , --option resolution 13 --option angle 20 --option laplace True
+        """),
+    )
+    parser.add_argument(
+        "directory",
+        type=str,
+        help="Directory with fitting results.",
+    )
+    parser.add_argument(
+        "target",
+        type=str,
+        help="Target density map to fit the model in. "
+        "Data should either be in CCP4 or MRC format",
+    )
+    parser.add_argument(
+        "-n",
+        "--num",
+        dest="num",
+        type=int,
+        default=10,
+        metavar="<int>",
+        help="Number of models written to file. This number "
+        "will be capped if less solutions are found as requested.",
+    )
+    parser.add_argument(
+        "--delimiter",
+        dest="delimiter",
+        type=str,
+        default=",",
+        metavar="<str>",
+        help="Delimiter used in the 'solutions.out' file. For example use ',' or '\\t'. Defaults to fixed width.",
+    )
+    parser.add_argument(
+        "--option",
+        action="append",
+        nargs=2,
+        metavar=("KEY", "VALUE"),
+        default=[],
+        help="Option used for fitting, to include in the report. "
+        "Can be used multiple times. Example: --option resolution 13",
+    )
+    args = parser.parse_args()
+
+    generate_report(
+        args.directory, args.target, args.num, args.delimiter, dict(args.option)
+    )

--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -101,13 +101,12 @@ def _add_model_to_builder(
     return component.focus(radius_factor=3).representation().color(color="blue")
 
 
-def _create_snapshot_description(
-    solution: dict[str, Any], fitted_model_file: Path
-) -> str:
+def _create_snapshot_description(solution: dict[str, Any]) -> str:
     translation = f"({solution['x']}, {solution['y']}, {solution['z']})"
     rotation = f"(({solution['a11']}, {solution['a12']}, {solution['a13']}), "
     rotation += f"({solution['a21']}, {solution['a22']}, {solution['a23']}), "
     rotation += f"({solution['a31']}, {solution['a32']}, {solution['a33']}))"
+    fitted_model_file = solution["fitted_model_file"]
     return dedent(f"""
             - Rank: {solution["rank"]}
             - Fitted model: [{fitted_model_file.name}]({fitted_model_file.name})
@@ -120,13 +119,12 @@ def _create_snapshot_description(
         """)
 
 
-def create_snapshot(
-    solution: dict, fitted_model_file: Path, density: Path, rel_iso_value: float
-) -> Snapshot:
+def create_snapshot(solution: dict, density: Path, rel_iso_value: float) -> Snapshot:
     builder = create_builder()
+    fitted_model_file = solution["fitted_model_file"]
     _add_density_to_builder(builder, density, rel_iso_value)
     _add_model_to_builder(builder, fitted_model_file)
-    description = _create_snapshot_description(solution, fitted_model_file)
+    description = _create_snapshot_description(solution)
     return builder.get_snapshot(
         key=fitted_model_file.stem,
         title=solution["rank"],
@@ -171,11 +169,12 @@ def _read_solutions(path: Path, delimiter: str | None = None) -> list[dict]:
     with open(path, "r") as f:
         reader = csv.DictReader(f, delimiter=delimiter)
         solutions = list(reader)
-    # Calculate sigma_dif for each solution
+    # Calculate sigma_dif for each solution and add fitted_model_file
     if solutions:
         best_z = float(solutions[0]["Fish-z"])
-        for solution in solutions:
+        for i, solution in enumerate(solutions):
             solution["sigma_dif"] = round(float(solution["rel-z"]) - best_z, 3)
+            solution["fitted_model_file"] = Path(path.parent) / f"fit_{i + 1}.pdb"
     return solutions
 
 
@@ -551,9 +550,10 @@ def generated_table(solutions: list[dict[str, Any]]) -> str:
         else:
             class_name = "close-sigma-gt3"
         snapshot_key = f"fit_{solution['rank']}"
+        fitted_model_file = solution["fitted_model_file"]
         table += dedent(f"""\
             <tr class="{class_name}">
-              <td>{solution["rank"]}</td>
+              <td><a href="{fitted_model_file.name}" target="_blank" title="Download fitted model">{solution["rank"]}</a></td>
               <td>{solution["cc"]}</td>
               <td>{solution["Fish-z"]}</td>
               <td>{solution["rel-z"]}</td>
@@ -600,15 +600,10 @@ def generate_report(
 
     solutions_file = run_dir / "solutions.out"
     solutions = _read_solutions(solutions_file, delimiter)
-    fitted_model_files = []
+    fitted_model_files = [solution["fitted_model_file"] for solution in solutions[:num]]
     snapshots = []
-    for i, solution in enumerate(solutions):
-        if i >= num:
-            # Can only visualize written models
-            break
-        fitted_model_file = run_dir / f"fit_{i + 1}.pdb"
-        fitted_model_files.append(fitted_model_file)
-        snapshot = create_snapshot(solution, fitted_model_file, target_path, iso.value)
+    for i, solution in enumerate(solutions[:num]):
+        snapshot = create_snapshot(solution, target_path, iso.value)
         snapshots.append(snapshot)
     snapshots.append(
         create_snapshot_with_all_models(fitted_model_files, target_path, iso.value)

--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -111,7 +111,7 @@ def _create_snapshot_description(solution: dict[str, Any]) -> str:
             - Rank: {solution["rank"]}
             - Fitted model: [{fitted_model_file.name}]({fitted_model_file.name})
             - Cross correlation score: {solution["cc"]}
-            - Fish-z score: {solution["Fish-z"]}
+            - Fisher z-score: {solution["Fish-z"]}
             - Relative z-score (z-score/α: {solution["rel-z"]}
             - Sigma difference (z₁-zₙ/α): {solution["sigma_dif"]}
             - Translation: {translation}

--- a/src/powerfit_em/report.py
+++ b/src/powerfit_em/report.py
@@ -113,7 +113,8 @@ def _create_snapshot_description(
             - Fitted model: [{fitted_model_file.name}]({fitted_model_file.name})
             - Cross correlation score: {solution["cc"]}
             - Fish-z score: {solution["Fish-z"]}
-            - Rel-z score: {solution["rel-z"]}
+            - Relative z-score (z-score/α: {solution["rel-z"]}
+            - Sigma difference (z₁-zₙ/α): {solution["sigma_dif"]}
             - Translation: {translation}
             - Rotation: {rotation}
         """)
@@ -170,6 +171,11 @@ def _read_solutions(path: Path, delimiter: str | None = None) -> list[dict]:
     with open(path, "r") as f:
         reader = csv.DictReader(f, delimiter=delimiter)
         solutions = list(reader)
+    # Calculate sigma_dif for each solution
+    if solutions:
+        best_z = float(solutions[0]["Fish-z"])
+        for solution in solutions:
+            solution["sigma_dif"] = round(float(solution["rel-z"]) - best_z, 3)
     return solutions
 
 
@@ -489,9 +495,8 @@ def generated_table(solutions: list[dict[str, Any]]) -> str:
         </thead>
         <tbody>
         """)
-    best_z = float(solutions[0]["Fish-z"])
     for solution in solutions:
-        sigma_dif = round(float(solution["rel-z"]) - best_z, 3)
+        sigma_dif = solution["sigma_dif"]
         if sigma_dif < 1:
             class_name = "close-sigma-lt1"
         elif sigma_dif < 2:


### PR DESCRIPTION
Fixes #84 

<img width="1048" height="934" alt="Screenshot from 2025-10-07 13-02-39" src="https://github.com/user-attachments/assets/ea6d3c4e-dd63-4031-a2f3-5bc0787f2ca5" />
(for screenshot the rel-z was manually adjusted to show colors)

Besides #84, it also adds
- add sigma difference to card
- synced headers in table with keys in card
- link to fitted model in rank column
- button to show solution in 3D
  - is disabled when it already being shown. 
  - disable-ment updates when Molstar snapshot is changed.
- command to generate report of existing results dir. For example `python3 -m powerfit_em.report run ribosome-KsgA.map -n 20 --delimiter , --option resolution 13 --option angle 20 --option laplace True`.