### PR TITLE
Allow for gzipped target files

### DIFF
--- a/src/powerfit_em/__init__.py
+++ b/src/powerfit_em/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 from .volume import Volume, structure_to_shape_like
 from .structure import Structure

--- a/src/powerfit_em/volume.py
+++ b/src/powerfit_em/volume.py
@@ -1,5 +1,7 @@
 
+import gzip
 from io import BufferedReader
+from pathlib import Path
 from struct import unpack as _unpack, pack as _pack
 import os.path
 from sys import byteorder as _BYTEORDER
@@ -232,12 +234,20 @@ def parse_volume(fid, fmt=None):
         fname = fid
 
     if fmt is None:
-        fmt = os.path.splitext(fname)[-1][1:]
-    if fmt in ('ccp4', 'map'):
+        fp = Path(fname)
+        fmt = fp.suffix
+        if fmt == ".gz":
+            fmt = fp.suffixes[-2] + fmt
+    
+    if fmt in ('.ccp4', '.map'):
         p = CCP4Parser(fid)
-    elif fmt == 'mrc':
+    elif fmt in (".ccp4.gz", ".map.gz"):
+        p = CCP4Parser(gzip.GzipFile(fileobj=fid, mode="rb"))
+    elif fmt == '.mrc':
         p = MRCParser(fname)
-    elif fmt in ('xplor', 'cns'):
+    elif fmt == ".mrc.gz":
+        p = MRCParser(gzip.GzipFile(fileobj=fid, mode="rb"))
+    elif fmt in ('.xplor', '.cns'):
         p = XPLORParser(fname)
     else:
         raise ValueError('Extension of file is not supported.')
@@ -258,11 +268,14 @@ class CCP4Parser(object):
     HEADER_CHUNKS = [1] * 25 + [9, 3, 12] + [1] * 3 + [4, 4, 1, 1, 800]
 
     def __init__(self, fid):
-
+        gzipped = False
         if isinstance(fid, str):
             fhandle = open(fid, 'rb')
         elif isinstance(fid, BufferedReader):
             fhandle = fid
+        elif isinstance(fid, gzip.GzipFile):
+            fhandle = fid
+            gzipped = True
         else:
             raise ValueError("Input should either be a file or filename.")
 
@@ -308,7 +321,7 @@ class CCP4Parser(object):
         # generate the density
         shape_fields = 'nz ny nx'.split()
         self.shape = [self.header[field] for field in shape_fields]
-        self._get_density()
+        self._get_density(gzipped)
 
     def _get_endiannes(self):
         self.fhandle.seek(212)
@@ -351,7 +364,7 @@ class CCP4Parser(object):
         start = [start[x - 1] for x in self.order]
         return np.asarray([x * self.voxelspacing for x in start])
 
-    def _get_density(self):
+    def _get_density(self, gzipped: bool):
 
         # Determine the dtype of the file based on the mode
         mode = self.header['mode']
@@ -361,8 +374,14 @@ class CCP4Parser(object):
             dtype = 'i2'
         elif mode == 2:
             dtype = 'f4'
+        else:
+            msg = f"Unknown mode '{mode}' in file header."
+            raise ValueError(msg)
 
-        density = np.fromfile(self.fhandle, dtype=self._endian + dtype).reshape(self.shape)
+        if gzipped:
+            density = np.frombuffer(self.fhandle.read(), dtype=self._endian + dtype).reshape(self.shape)
+        else:
+            density = np.fromfile(self.fhandle, dtype=self._endian + dtype).reshape(self.shape)
         if self.order == (1, 3, 2):
             self.density = np.swapaxes(self.density, 0, 1)
         elif self.order == (2, 1, 3):
@@ -381,7 +400,7 @@ class CCP4Parser(object):
             density = density.astype(np.int32)
         elif mode == 2:
             density = density.astype(np.float64)
-        self.density =density
+        self.density = density
 
     def _get_order(self):
         self.order = tuple(self.header[axis] for axis in ('mapc', 'mapr',
@@ -389,7 +408,6 @@ class CCP4Parser(object):
 
 
 class MRCParser(CCP4Parser):
-
     def _get_origin(self):
         origin_fields = 'xstart ystart zstart'.split()
         origin = [self.header[field] for field in origin_fields]

--- a/src/powerfit_em/volume.py
+++ b/src/powerfit_em/volume.py
@@ -20,10 +20,19 @@ class Volume(object):
         return cls(array, voxelspacing, origin)
 
     def __init__(self, array, voxelspacing=1.0, origin=(0, 0, 0)):
-
         self.array = array
         self.voxelspacing = voxelspacing
         self.origin = origin
+    
+    def __eq__(self, other):
+        if isinstance(other, Volume):
+            return (
+                (self.array == other.array).all() and
+                self.voxelspacing == other.voxelspacing and
+                self.origin == other.origin
+            )
+        else:
+            return NotImplemented
 
     @property
     def shape(self):
@@ -242,11 +251,11 @@ def parse_volume(fid, fmt=None):
     if fmt in ('.ccp4', '.map'):
         p = CCP4Parser(fid)
     elif fmt in (".ccp4.gz", ".map.gz"):
-        p = CCP4Parser(gzip.GzipFile(fileobj=fid, mode="rb"))
+        p = CCP4Parser(fid, gzipped=True)
     elif fmt == '.mrc':
         p = MRCParser(fname)
     elif fmt == ".mrc.gz":
-        p = MRCParser(gzip.GzipFile(fileobj=fid, mode="rb"))
+        p = MRCParser(fname, gzipped=True)
     elif fmt in ('.xplor', '.cns'):
         p = XPLORParser(fname)
     else:
@@ -267,15 +276,17 @@ class CCP4Parser(object):
           ).split()
     HEADER_CHUNKS = [1] * 25 + [9, 3, 12] + [1] * 3 + [4, 4, 1, 1, 800]
 
-    def __init__(self, fid):
-        gzipped = False
+    def __init__(self, fid, gzipped: bool = False):
         if isinstance(fid, str):
-            fhandle = open(fid, 'rb')
+            if gzipped:
+                fhandle = gzip.open(fid, mode="rb")
+            else:
+                fhandle = open(fid, mode="rb")
         elif isinstance(fid, BufferedReader):
-            fhandle = fid
-        elif isinstance(fid, gzip.GzipFile):
-            fhandle = fid
-            gzipped = True
+            if gzipped:
+                fhandle = gzip.GzipFile(fileobj=fid, mode="rb")
+            else:
+                fhandle = fid
         else:
             raise ValueError("Input should either be a file or filename.")
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,3 +1,4 @@
+import gzip
 from pathlib import Path
 
 import numpy as np
@@ -17,15 +18,25 @@ def example_volume() -> Volume:
 
 
 @pytest.fixture
-def example_nrc_file(tmp_path: Path, example_volume: Volume) -> Path:
+def example_mrc_file(tmp_path: Path, example_volume: Volume) -> Path:
     fn = tmp_path / "example_volume.mrc"
     example_volume.tofile(fn)
     return fn
 
+@pytest.fixture
+def example_gz_file(tmp_path: Path, example_mrc_file: Path) -> Path:
+    with open(example_mrc_file, mode="rb") as f:
+        mrc_file = f.read()
+    
+    fn = tmp_path / "example_volume.mrc.gz"
+    with gzip.open(fn, "wb") as f:
+        f.write(mrc_file)
+    return fn
 
-def test_to_file(example_nrc_file: Path):
-    assert example_nrc_file.exists()
-    assert example_nrc_file.stat().st_size > 0
+
+def test_to_file(example_mrc_file: Path):
+    assert example_mrc_file.exists()
+    assert example_mrc_file.stat().st_size > 0
 
 
 def test_shape(example_volume: Volume):
@@ -40,8 +51,8 @@ def test_get_start(example_volume: Volume):
     npt.assert_array_equal(example_volume.start, (0, 0, 0))
 
 
-def test_fromfile(example_nrc_file: Path):
-    volume = Volume.fromfile(str(example_nrc_file))
+def test_fromfile(example_mrc_file: Path):
+    volume = Volume.fromfile(str(example_mrc_file))
 
     assert volume.shape == (3, 4, 5)
     npt.assert_array_equal(volume.start, (0, 0, 0))
@@ -51,3 +62,9 @@ def test_fromfile(example_nrc_file: Path):
     expected[1, 2, 3] = 2.2
     expected[2, 3, 4] = 3.3
     npt.assert_array_almost_equal(volume.array, expected)
+
+
+def test_read_gzip(example_mrc_file: Path, example_gz_file: Path):
+    mrc = Volume.fromfile(str(example_mrc_file))
+    mrcgz = Volume.fromfile(str(example_gz_file))
+    assert mrc == mrcgz


### PR DESCRIPTION
- Powerfit can now read gzipped .mrc and .ccp4/.map files. This can significantly reduce disk space and I/O in some cases.
- Bumped version to 3.2.0

Note that I only added a test for .mrc files, as Powerfit can write this file format, and this is nearly identical to the CCP4 format, except for the `_get_origin` implementation)