### PR TITLE
add script to compare correlators

### DIFF
--- a/tests/scripts/bench_correlators.py
+++ b/tests/scripts/bench_correlators.py
@@ -3,119 +3,162 @@ Usage:
     uv run python tests/scripts/bench_correlators.py
 """
 
+import itertools
+import os
 import re
 import shutil
 import subprocess
 import tempfile
 import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-
-RESOLUTION = 13
-NPROCS = (1, 4, 16)
-ANGLES = (20, 10)
-COMMIT = "ab1800d"  # CPUCorrelator (python) vs CpuRustCorrelator (rust) are in the same commit
-ENGINES = [("python", None), ("rust", "--rust")]
+from urllib.parse import urlparse
 
 
-def run(cmd: list, cwd: Path | None = None) -> None:
-    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
-    if result.returncode != 0:
-        print(result.stdout)
-        print(result.stderr)
-        result.check_returncode()
+@dataclass(frozen=True)
+class Engine:
+    identifier: str
+    commit: str
+    flag: str | None = None
+    optimize: bool = False
+
+    def setup_clone(self) -> Path:
+        clone_dir = Path(tempfile.mkdtemp(prefix="pf-bench-"))
+        print(f"-> cloning {self.commit}")
+        self.run(["git", "clone", "https://github.com/haddocking/powerfit.git", str(clone_dir)])
+        self.run(["git", "-C", str(clone_dir), "checkout", self.commit])
+        print("-> building venv")
+        self.run(["uv", "venv", ".venv", "--python=3.14"], cwd=clone_dir)
+
+        print("-> installing" + (" (target-cpu=native)" if self.optimize else ""))
+        env = {"RUSTFLAGS": "-C target-cpu=native"} if self.optimize else None
+        self.run(["uv", "pip", "install", "--python", ".venv/bin/python", "-e", "."], cwd=clone_dir, env=env)
+
+        return clone_dir
+
+    @contextmanager
+    def cloned(self) -> Iterator[Path]:
+        clone_dir = self.setup_clone()
+        try:
+            yield clone_dir
+        finally:
+            shutil.rmtree(clone_dir, ignore_errors=True)
+
+    def run_powerfit(
+        self,
+        clone_dir: Path,
+        map_path: Path,
+        pdb_path: Path,
+        angle: float,
+        resolution: float,
+        nproc: int,
+        out_dir: Path,
+    ) -> float:
+        cmd = [str(clone_dir / ".venv" / "bin" / "powerfit")]
+        if self.flag:
+            cmd.append(self.flag)
+        cmd += [
+            str(map_path),
+            str(resolution),
+            str(pdb_path),
+            "-a",
+            str(angle),
+            "--delimiter",
+            ",",
+            "-n",
+            "0",
+            "--nproc",
+            str(nproc),
+            "-d",
+            str(out_dir),
+            "--log-level",
+            "INFO",
+        ]
+        log_text = self.run(cmd, cwd=clone_dir)
+        (out_dir / "powerfit.log").write_text(log_text)
+        return self.parse_search_seconds(log_text)
+
+    @staticmethod
+    def run(cmd: list, cwd: Path | None = None, env: dict | None = None) -> str:
+        full_env = {**os.environ, **env} if env else None
+        result = subprocess.run(cmd, cwd=cwd, env=full_env, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            print(result.stdout)
+            print(result.stderr)
+            result.check_returncode()
+        return result.stdout + result.stderr
+
+    @staticmethod
+    def parse_search_seconds(log_text: str) -> float:
+        match = re.compile(r"Time for search: (?:(\d+)m )?([\d.]+)\s*s").search(log_text)
+        if match is None:
+            msg = f"could not find 'Time for search' line in log:\n{log_text}"
+            raise ValueError(msg)
+        minutes, seconds = match.groups()
+        return (int(minutes) * 60 if minutes else 0) + float(seconds)
 
 
-def fetch_data() -> tuple[Path, Path]:
-    print("-> fetching tutorial data")
+def fetch_data(map_url: str, pdb_url: str) -> tuple[Path, Path]:
+    print("-> fetching data")
     data_dir = Path(tempfile.mkdtemp(prefix="pf-bench-data"))
-    map_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/ribosome-KsgA.map"
-    pdb_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/KsgA.pdb"
 
-    map_path = data_dir / "ribosome-KsgA.map"
-    pdb_path = data_dir / "KsgA.pdb"
-    urllib.request.urlretrieve(map_url, map_path)  # noqa: S310
-    urllib.request.urlretrieve(pdb_url, pdb_path)  # noqa: S310
+    map_path = data_dir / Path(urlparse(map_url).path).name
+    pdb_path = data_dir / Path(urlparse(pdb_url).path).name
+
+    urllib.request.urlretrieve(map_url, map_path)
+    urllib.request.urlretrieve(pdb_url, pdb_path)
 
     return map_path, pdb_path
 
 
-def setup_clone(commit: str) -> Path:
-    clone_dir = Path(tempfile.mkdtemp(prefix="pf-bench-"))
-    print(f"-> cloning {commit}")
-    run(["git", "clone", "https://github.com/haddocking/powerfit.git", str(clone_dir)])
-    run(["git", "-C", str(clone_dir), "checkout", commit])
-    print("-> building venv")
-    run(["uv", "venv", ".venv", "--python=3.14"], cwd=clone_dir)
-    run(["uv", "pip", "install", "--python", ".venv/bin/python", "-e", "."], cwd=clone_dir)
-    return clone_dir
-
-
-def parse_search_seconds(log_text: str) -> float:
-    match = re.compile(r"Time for search: (?:(\d+)m )?([\d.]+)\s*s").search(log_text)
-    if match is None:
-        msg = f"could not find 'Time for search' line in log:\n{log_text}"
-        raise ValueError(msg)
-    minutes, seconds = match.groups()
-    return (int(minutes) * 60 if minutes else 0) + float(seconds)
-
-
-def run_powerfit(
-    clone_dir: Path,
-    flag: str | None,
-    map_path: Path,
-    pdb_path: Path,
-    angle: float,
-    nproc: int,
-    out_dir: Path,
-) -> float:
-    cmd = []
-    cmd.append(clone_dir / ".venv" / "bin" / "powerfit")
-    if flag:
-        cmd.append(flag)
-    cmd += [
-        str(map_path),
-        str(RESOLUTION),
-        str(pdb_path),
-        "-a",
-        str(angle),
-        "--delimiter",
-        ",",
-        "-n",
-        "0",
-        "--nproc",
-        str(nproc),
-        "-d",
-        str(out_dir),
-        "--log-level",
-        "INFO",
-    ]
-    result = subprocess.run(cmd, cwd=clone_dir, capture_output=True, text=True, check=True)
-    log_text = result.stdout + result.stderr
-    (out_dir / "powerfit.log").write_text(log_text)
-    return parse_search_seconds(log_text)
-
-
 def main() -> None:
-    map_path, pdb_path = fetch_data()
 
-    clone_dir = setup_clone(COMMIT)
+    nprocs = (1, 4, 16)
 
-    try:
-        print("-> running benchmarks")
-        rows = []
-        for angle in ANGLES:
-            for nproc in NPROCS:
-                for identifier, flag in ENGINES:
-                    print(f"   {identifier:<6} nproc={nproc:<2} angle={angle:<2} ", end="", flush=True)
-                    # NOTE: dump results, we only need the times
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        seconds = run_powerfit(clone_dir, flag, map_path, pdb_path, angle, nproc, Path(tmpdir))
+    # paper data
+    map_url = "https://ftp.ebi.ac.uk/pub/databases/emdb/structures/EMD-1046/map/emd_1046.map.gz"
+    pdb_url = "https://files.rcsb.org/download/9A2G.cif.gz"
+    resolution = 20
+    angles = (4.71,)
 
-                    rows.append((identifier, nproc, angle, seconds))
-                    print(f"{seconds:.3f}s")
-    finally:
-        print("-> cleaning up")
-        shutil.rmtree(clone_dir, ignore_errors=True)
+    # "tutorial" data
+    # map_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/ribosome-KsgA.map"
+    # pdb_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/KsgA.pdb"
+    # resolution = 13
+    # angles = (10, 20)
+
+    ENGINES = [
+        Engine("baseline", "cf1e3f8"),  # v5.0.2
+        Engine("python", "ab1800d"),
+        Engine("rust-native", "ab1800d", flag="--rust", optimize=True),
+        Engine("rust", "ab1800d", flag="--rust"),
+    ]
+
+    map_path, pdb_path = fetch_data(map_url=map_url, pdb_url=pdb_url)
+
+    print("-> running benchmarks")
+    rows = []
+    for engine in ENGINES:
+        # NOTE: context here to make cleaning easier
+        with engine.cloned() as clone_dir:
+            for angle, nproc in itertools.product(angles, nprocs):
+                print(f"   {engine.identifier:<6} nproc={nproc:<2} angle={angle:<2} ", end="", flush=True)
+                # NOTE: dump results, we only need the times
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    seconds = engine.run_powerfit(
+                        clone_dir=clone_dir,
+                        map_path=map_path,
+                        pdb_path=pdb_path,
+                        angle=angle,
+                        resolution=resolution,
+                        nproc=nproc,
+                        out_dir=Path(tmpdir),
+                    )
+
+                rows.append((engine.identifier, nproc, angle, seconds))
+                print(f"{seconds:.3f}s")
 
     summary_path = Path.cwd() / "summary.csv"
     with summary_path.open("w") as f:

--- a/tests/scripts/bench_correlators.py
+++ b/tests/scripts/bench_correlators.py
@@ -1,0 +1,124 @@
+"""
+Usage:
+    uv run python tests/scripts/bench_correlators.py
+"""
+
+import re
+import shutil
+import subprocess
+import tempfile
+import urllib.request
+from pathlib import Path
+
+RESOLUTION = 13
+NPROCS = (1, 4, 16)
+ANGLES = (20, 10)
+ENGINES = [("cython", "9a11eed", None), ("python", "ab1800d", None), ("rust", "ab1800d", "--rust")]
+
+
+def fetch_data() -> tuple[Path, Path]:
+    data_dir = Path(tempfile.mkdtemp(prefix="pf-bench-data"))
+    map_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/ribosome-KsgA.map"
+    pdb_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/KsgA.pdb"
+
+    map_path = data_dir / "ribosome-KsgA.map"
+    pdb_path = data_dir / "KsgA.pdb"
+    urllib.request.urlretrieve(map_url, map_path)  # noqa: S310
+    urllib.request.urlretrieve(pdb_url, pdb_path)  # noqa: S310
+
+    return map_path, pdb_path
+
+
+def setup_clone(commit: str) -> Path:
+    clone_dir = Path(tempfile.mkdtemp(prefix="pf-bench-"))
+    subprocess.run(["git", "clone", "https://github.com/haddocking/powerfit.git", str(clone_dir)], check=True)
+    subprocess.run(["git", "-C", str(clone_dir), "checkout", commit], check=True)
+    subprocess.run(["uv", "venv", ".venv", "--python=3.14"], cwd=clone_dir, check=True)
+    subprocess.run(
+        ["uv", "pip", "install", "--python", ".venv/bin/python", "-e", "."],
+        cwd=clone_dir,
+        check=True,
+    )
+    return clone_dir
+
+
+def parse_search_seconds(log_text: str) -> float:
+    match = re.compile(r"Time for search: (?:(\d+)m )?([\d.]+)\s*s").search(log_text)
+    if match is None:
+        msg = f"could not find 'Time for search' line in log:\n{log_text}"
+        raise ValueError(msg)
+    minutes, seconds = match.groups()
+    return (int(minutes) * 60 if minutes else 0) + float(seconds)
+
+
+def run_powerfit(
+    clone_dir: Path,
+    flag: str | None,
+    map_path: Path,
+    pdb_path: Path,
+    angle: float,
+    nproc: int,
+    out_dir: Path,
+) -> float:
+    cmd = []
+    cmd.append(clone_dir / ".venv" / "bin" / "powerfit")
+    if flag:
+        cmd.append(flag)
+    cmd += [
+        str(map_path),
+        str(RESOLUTION),
+        str(pdb_path),
+        "-a",
+        str(angle),
+        "--delimiter",
+        ",",
+        "-n",
+        "0",
+        "--nproc",
+        str(nproc),
+        "-d",
+        str(out_dir),
+        "--log-level",
+        "INFO",
+    ]
+    result = subprocess.run(cmd, cwd=clone_dir, capture_output=True, text=True, check=True)
+    log_text = result.stdout + result.stderr
+    (out_dir / "powerfit.log").write_text(log_text)
+    return parse_search_seconds(log_text)
+
+
+def main() -> None:
+    map_path, pdb_path = fetch_data()
+
+    # one clone per unique commit -- python and rust share ab1800d
+    commits = {commit for _, commit, _ in ENGINES}
+    clone_by_commit: dict[str, Path] = {}
+    for commit in commits:
+        clone_by_commit[commit] = setup_clone(commit)
+
+    try:
+        rows = []
+        for angle in ANGLES:
+            for nproc in NPROCS:
+                for identifier, commit, flag in ENGINES:
+                    clone_dir = clone_by_commit[commit]
+                    # NOTE: dump results, we only need the times
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        seconds = run_powerfit(clone_dir, flag, map_path, pdb_path, angle, nproc, Path(tmpdir))
+
+                    rows.append((identifier, nproc, angle, seconds))
+    finally:
+        for clone_dir in clone_by_commit.values():
+            shutil.rmtree(clone_dir, ignore_errors=True)
+
+    summary_path = Path.cwd() / "summary.csv"
+    with summary_path.open("w") as f:
+        f.write("engine,nproc,angle,search_seconds\n")
+        for engine, nproc, angle, seconds in rows:
+            f.write(f"{engine},{nproc},{angle},{seconds:.3f}\n")
+
+    print(f"summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/bench_correlators.py
+++ b/tests/scripts/bench_correlators.py
@@ -100,17 +100,20 @@ class Engine:
         return (int(minutes) * 60 if minutes else 0) + float(seconds)
 
 
-def fetch_data(map_url: str, pdb_url: str) -> tuple[Path, Path]:
+@contextmanager
+def fetch_data(map_url: str, pdb_url: str) -> Iterator[tuple[Path, Path]]:
     print("-> fetching data")
-    data_dir = Path(tempfile.mkdtemp(prefix="pf-bench-data"))
+    data_dir = Path(tempfile.mkdtemp(prefix="pf-bench-data-"))
+    try:
+        map_path = data_dir / Path(urlparse(map_url).path).name
+        pdb_path = data_dir / Path(urlparse(pdb_url).path).name
 
-    map_path = data_dir / Path(urlparse(map_url).path).name
-    pdb_path = data_dir / Path(urlparse(pdb_url).path).name
+        urllib.request.urlretrieve(map_url, map_path)
+        urllib.request.urlretrieve(pdb_url, pdb_path)
 
-    urllib.request.urlretrieve(map_url, map_path)
-    urllib.request.urlretrieve(pdb_url, pdb_path)
-
-    return map_path, pdb_path
+        yield map_path, pdb_path
+    finally:
+        shutil.rmtree(data_dir, ignore_errors=True)
 
 
 def main() -> None:
@@ -136,29 +139,29 @@ def main() -> None:
         Engine("rust", "ab1800d", flag="--rust"),
     ]
 
-    map_path, pdb_path = fetch_data(map_url=map_url, pdb_url=pdb_url)
-
     print("-> running benchmarks")
     rows = []
-    for engine in ENGINES:
-        # NOTE: context here to make cleaning easier
-        with engine.cloned() as clone_dir:
-            for angle, nproc in itertools.product(angles, nprocs):
-                print(f"   {engine.identifier:<6} nproc={nproc:<2} angle={angle:<2} ", end="", flush=True)
-                # NOTE: dump results, we only need the times
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    seconds = engine.run_powerfit(
-                        clone_dir=clone_dir,
-                        map_path=map_path,
-                        pdb_path=pdb_path,
-                        angle=angle,
-                        resolution=resolution,
-                        nproc=nproc,
-                        out_dir=Path(tmpdir),
-                    )
+    # NOTE: context here to make cleaning easier
+    with fetch_data(map_url=map_url, pdb_url=pdb_url) as (map_path, pdb_path):
+        for engine in ENGINES:
+            # NOTE: context here to make cleaning easier
+            with engine.cloned() as clone_dir:
+                for angle, nproc in itertools.product(angles, nprocs):
+                    print(f"   {engine.identifier:<6} nproc={nproc:<2} angle={angle:<2} ", end="", flush=True)
+                    # NOTE: dump results, we only need the times
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        seconds = engine.run_powerfit(
+                            clone_dir=clone_dir,
+                            map_path=map_path,
+                            pdb_path=pdb_path,
+                            angle=angle,
+                            resolution=resolution,
+                            nproc=nproc,
+                            out_dir=Path(tmpdir),
+                        )
 
-                rows.append((engine.identifier, nproc, angle, seconds))
-                print(f"{seconds:.3f}s")
+                    rows.append((engine.identifier, nproc, angle, seconds))
+                    print(f"{seconds:.3f}s")
 
     summary_path = Path.cwd() / "summary.csv"
     with summary_path.open("w") as f:

--- a/tests/scripts/bench_correlators.py
+++ b/tests/scripts/bench_correlators.py
@@ -13,7 +13,8 @@ from pathlib import Path
 RESOLUTION = 13
 NPROCS = (1, 4, 16)
 ANGLES = (20, 10)
-ENGINES = [("cython", "9a11eed", None), ("python", "ab1800d", None), ("rust", "ab1800d", "--rust")]
+COMMIT = "ab1800d"  # CPUCorrelator (python) vs CpuRustCorrelator (rust) are in the same commit
+ENGINES = [("python", None), ("rust", "--rust")]
 
 
 def fetch_data() -> tuple[Path, Path]:
@@ -90,26 +91,20 @@ def run_powerfit(
 def main() -> None:
     map_path, pdb_path = fetch_data()
 
-    # one clone per unique commit -- python and rust share ab1800d
-    commits = {commit for _, commit, _ in ENGINES}
-    clone_by_commit: dict[str, Path] = {}
-    for commit in commits:
-        clone_by_commit[commit] = setup_clone(commit)
+    clone_dir = setup_clone(COMMIT)
 
     try:
         rows = []
         for angle in ANGLES:
             for nproc in NPROCS:
-                for identifier, commit, flag in ENGINES:
-                    clone_dir = clone_by_commit[commit]
+                for identifier, flag in ENGINES:
                     # NOTE: dump results, we only need the times
                     with tempfile.TemporaryDirectory() as tmpdir:
                         seconds = run_powerfit(clone_dir, flag, map_path, pdb_path, angle, nproc, Path(tmpdir))
 
                     rows.append((identifier, nproc, angle, seconds))
     finally:
-        for clone_dir in clone_by_commit.values():
-            shutil.rmtree(clone_dir, ignore_errors=True)
+        shutil.rmtree(clone_dir, ignore_errors=True)
 
     summary_path = Path.cwd() / "summary.csv"
     with summary_path.open("w") as f:

--- a/tests/scripts/bench_correlators.py
+++ b/tests/scripts/bench_correlators.py
@@ -17,7 +17,16 @@ COMMIT = "ab1800d"  # CPUCorrelator (python) vs CpuRustCorrelator (rust) are in 
 ENGINES = [("python", None), ("rust", "--rust")]
 
 
+def run(cmd: list, cwd: Path | None = None) -> None:
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr)
+        result.check_returncode()
+
+
 def fetch_data() -> tuple[Path, Path]:
+    print("-> fetching tutorial data")
     data_dir = Path(tempfile.mkdtemp(prefix="pf-bench-data"))
     map_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/ribosome-KsgA.map"
     pdb_url = "https://github.com/haddocking/powerfit-tutorial/raw/refs/heads/master/KsgA.pdb"
@@ -32,14 +41,12 @@ def fetch_data() -> tuple[Path, Path]:
 
 def setup_clone(commit: str) -> Path:
     clone_dir = Path(tempfile.mkdtemp(prefix="pf-bench-"))
-    subprocess.run(["git", "clone", "https://github.com/haddocking/powerfit.git", str(clone_dir)], check=True)
-    subprocess.run(["git", "-C", str(clone_dir), "checkout", commit], check=True)
-    subprocess.run(["uv", "venv", ".venv", "--python=3.14"], cwd=clone_dir, check=True)
-    subprocess.run(
-        ["uv", "pip", "install", "--python", ".venv/bin/python", "-e", "."],
-        cwd=clone_dir,
-        check=True,
-    )
+    print(f"-> cloning {commit}")
+    run(["git", "clone", "https://github.com/haddocking/powerfit.git", str(clone_dir)])
+    run(["git", "-C", str(clone_dir), "checkout", commit])
+    print("-> building venv")
+    run(["uv", "venv", ".venv", "--python=3.14"], cwd=clone_dir)
+    run(["uv", "pip", "install", "--python", ".venv/bin/python", "-e", "."], cwd=clone_dir)
     return clone_dir
 
 
@@ -94,16 +101,20 @@ def main() -> None:
     clone_dir = setup_clone(COMMIT)
 
     try:
+        print("-> running benchmarks")
         rows = []
         for angle in ANGLES:
             for nproc in NPROCS:
                 for identifier, flag in ENGINES:
+                    print(f"   {identifier:<6} nproc={nproc:<2} angle={angle:<2} ", end="", flush=True)
                     # NOTE: dump results, we only need the times
                     with tempfile.TemporaryDirectory() as tmpdir:
                         seconds = run_powerfit(clone_dir, flag, map_path, pdb_path, angle, nproc, Path(tmpdir))
 
                     rows.append((identifier, nproc, angle, seconds))
+                    print(f"{seconds:.3f}s")
     finally:
+        print("-> cleaning up")
         shutil.rmtree(clone_dir, ignore_errors=True)
 
     summary_path = Path.cwd() / "summary.csv"
@@ -112,7 +123,7 @@ def main() -> None:
         for engine, nproc, angle, seconds in rows:
             f.write(f"{engine},{nproc},{angle},{seconds:.3f}\n")
 
-    print(f"summary: {summary_path}")
+    print(f"-> summary: {summary_path}")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/bench_correlators.py
+++ b/tests/scripts/bench_correlators.py
@@ -3,6 +3,7 @@ Usage:
     uv run python tests/scripts/bench_correlators.py
 """
 
+import csv
 import itertools
 import os
 import re
@@ -116,6 +117,29 @@ def fetch_data(map_url: str, pdb_url: str) -> Iterator[tuple[Path, Path]]:
         shutil.rmtree(data_dir, ignore_errors=True)
 
 
+def print_chart(summary_path: Path, bar_width: int = 40) -> None:
+    """Make an ASCII chart."""
+    with summary_path.open(newline="") as f:
+        rows = [
+            (r["engine"], int(r["nproc"]), float(r["angle"]), float(r["search_seconds"])) for r in csv.DictReader(f)
+        ]
+    if not rows:
+        return
+
+    max_seconds = max(seconds for _, _, _, seconds in rows)
+
+    print("\n-> chart (search seconds)")
+    for angle in sorted({a for _, _, a, _ in rows}):
+        for nproc in sorted({n for _, n, a, _ in rows if a == angle}):
+            print(f"\n  angle={angle} nproc={nproc}")
+            for identifier, n, a, seconds in rows:
+                if n != nproc or a != angle:
+                    continue
+                bar_len = round(seconds / max_seconds * bar_width) if max_seconds else 0
+                bar = "#" * bar_len
+                print(f"    {identifier:<12} {bar} {seconds:.2f}s")
+
+
 def main() -> None:
 
     nprocs = (1, 4, 16)
@@ -170,6 +194,7 @@ def main() -> None:
             f.write(f"{engine},{nproc},{angle},{seconds:.3f}\n")
 
     print(f"-> summary: {summary_path}")
+    print_chart(summary_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
added a `bench_correlators.py` script to facilitate comparing `CPUCorrelator` vs `CpuRustCorrelator`. the script is a bit overkill as it will clone the repository and checkout a given commit in a temporary location, download the data and then run it - not using whatever git structure you already have. I prefer to run these comparison in isolated environment to avoid surprises and artifacts - and like this we can be sure its running a fair comparison.

so this one only needs `uv`, and you can run it as `uv run python tests/scripts/bench_correlators.py`

```text
$ uv run python tests/scripts/bench_correlators.py
-> fetching tutorial data
-> cloning ab1800d
-> building venv
-> running benchmarks
   python nproc=1  angle=20 5.623s
   rust   nproc=1  angle=20 5.140s
   python nproc=4  angle=20 1.952s
   rust   nproc=4  angle=20 1.658s
   python nproc=16 angle=20 1.676s
   rust   nproc=16 angle=20 1.739s
   python nproc=1  angle=10 66.000s
   rust   nproc=1  angle=10 63.000s
   python nproc=4  angle=10 20.000s
   rust   nproc=4  angle=10 20.000s
   python nproc=16 angle=10 14.000s
   rust   nproc=16 angle=10 20.000s
-> cleaning up
-> summary: /home/rodrigo/repos/powerfit/summary.csv
```

so looking at the numbers seems like using `CpuRustCorrelator` is better (in this specific case) with less cores and `CPUCorrelator` using `pyFFTW` better with more cores.
